### PR TITLE
SYS-679: Adds QDB database and email variables to the docker-compose environment

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -3,3 +3,16 @@
 # Used by settings.py for now to allow switching between postgres
 # and the built-in sqlite.
 DJANGO_RUN_ENV=psql
+
+# QDB database server
+QDB_DB_SERVER=obiwan.qdb.ucla.edu
+QDB_DB_DATABASE=qdb
+QDB_DB_USER=mgrlib
+# This one comes from secrets
+QDB_DB_PASSWORD_FILE=/run/secrets/qdb_password
+
+# Email server info
+QDB_SMTP_SERVER=smtp.gmail.com
+QDB_PORT=587
+QDB_FROM_ADDRESS=qdb.test.ucla.@gmail.com
+QDB_PASSWORD=unknown

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local app-specific secrets
+*secret*
+*password*
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.1"
 services:
   django:
     build: .
@@ -6,6 +6,8 @@ services:
       - .:/home/django/LBS
     ports: 
       - "8000:8000"
+    secrets:
+      - qdb_password
     env_file:
       - .docker-compose_django.env
       - .docker-compose_db.env
@@ -17,5 +19,8 @@ services:
       - .docker-compose_db.env
     volumes:
       - pg_data:/var/lib/postgresql/data/
+secrets:
+  qdb_password:
+    file: secret_qdb_password.txt
 volumes:
   pg_data:


### PR DESCRIPTION
This adds QDB database and email variables to the docker-compose environment.  The variables are added to `.docker-compose_django.env`.

The QDB database password is handled via a "secret", which allows the value to be isolated in a file outside of version control.  The value is only available within the running docker container, and not exposed via `docker inspect`.  It's still in plain text on developers' systems, so this is just a start.  Developers need to put a file `secret_qdb_password.txt` in `/path/to/projects/LBS/`.

`.gitignore` has been updated to exclude secret/password files from the repository.

Finally, version in `docker-compose.yml` is updated to 3.1, which seems to be needed to use secrets.  This will work with versions 1.13.1+ of docker-compose.
