### PR TITLE
SYS-694 - Link from admin interface to report page

### DIFF
--- a/lbs/qdb/templates/form.html
+++ b/lbs/qdb/templates/form.html
@@ -21,6 +21,7 @@
         <div id="user-tools">
             Welcome,
             <strong>{{request.user.username}}</strong>.
+            <a href="/admin/">View admin page</a> /
             <a href="/qdb/logout/">Log out</a>
         </div>
     </div>


### PR DESCRIPTION
Connected to [SYS-695](https://jira.library.ucla.edu/browse/SYS-695)

Add a link from the QDB report page that leads to the admin page. If the user is not logged in as admin, the admin login page should appear.

**Acceptance Criteria**
  - [x] A link on the QDB report page leads to the admin page

**Screenshots**
![image](https://user-images.githubusercontent.com/2350153/149438999-36bd3aad-956e-4b29-ba74-988e7f605db0.png)

**Changed Files**
```
 lbs/
    qdb/
        templates/
            form.html
```