### PR TITLE
SYS-695 - Link from admin interface to report page

### DIFF
--- a/lbs/lbs/settings.py
+++ b/lbs/lbs/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'lbs.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/lbs/templates/admin/base_site.html
+++ b/lbs/templates/admin/base_site.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n %}
+            {% block userlinks %}
+                {% if site_url %}
+                    <a href="/qdb/report/">{% translate 'View QDB Reports' %}</a> /
+                {% endif %}
+                {% if user.is_active and user.is_staff %}
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}
+                        <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
+                    {% endif %}
+                {% endif %}
+                {% if user.has_usable_password %}
+                <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
+                {% endif %}
+                <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+            {% endblock %}


### PR DESCRIPTION
Connected to [SYS-695](https://jira.library.ucla.edu/browse/SYS-695)

Add a link from the Admin pages that leads to the QDB report page.

**Acceptance Criteria**
  - [x] A link on the admin page leads to the QDB report page

**Screenshots**
![image](https://user-images.githubusercontent.com/2350153/149577442-c468c86b-848e-4de9-a8d9-86cf371ab3e7.png)

**Changed Files**
```
LBS/
    lbs/
        lbs/
            settings.py
        templates/
            admin/
                base_site.html
```