### PR TITLE
SYS-706: Add gunicorn and whitenoise for production support

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -25,3 +25,8 @@ QDB_SMTP_PORT=587
 QDB_FROM_ADDRESS=qdb.test.ucla.@gmail.com
 QDB_PASSWORD=unknown
 QDB_APP_IP=192.168.1.1
+
+# For createsuperuser
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_PASSWORD=admin
+DJANGO_SUPERUSER_EMAIL=softwaredev-systems@library.ucla.edu

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 *secret*
 *password*
 
+# Local static files colleced when testing gunicorn and whitenoise
+staticfiles/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ RUN pip install --no-cache-dir -r lbs/requirements.txt --user --no-warn-script-l
 # Expose the typical Django port
 EXPOSE 8000
 
-# For now, use the built-in Django application server when the container starts
-CMD [ "python", "lbs/manage.py", "runserver", "0.0.0.0:8000" ]
+# When container starts, run script for environment-specific actions
+CMD [ "sh", "docker_scripts/entrypoint.sh" ]

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# LBS Django project may have multiple applications, though only 1 at present
+APP_DIR=lbs
+
+# Pick up any local changes to requirements.txt, which do *not* automatically get re-installed when starting the container.
+# Do this only in dev environment!
+if [ "$DJANGO_RUN_ENV" = "dev" ]; then
+  pip install --no-cache-dir -r "$APP_DIR"/requirements.txt --user --no-warn-script-location
+fi
+
+# Check when database is ready for connections
+echo "Checking database connectivity..."
+until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+  echo "Database connection not ready - waiting"
+  sleep 5
+done
+
+# Run database migrations
+python "$APP_DIR"/manage.py migrate
+
+if [ "$DJANGO_RUN_ENV" = "dev" ]; then
+  # Create default superuser for dev environment, using django env vars.
+  # Logs will show error if this exists, which is OK.
+  python "$APP_DIR"/manage.py createsuperuser --no-input
+fi
+
+if [ "$DJANGO_RUN_ENV" = "dev" ]; then
+  python "$APP_DIR"/manage.py runserver 0.0.0.0:8000
+else
+  # Build static files directory, starting fresh each time - do we really need this?
+  python "$APP_DIR"/manage.py collectstatic --no-input
+
+  # Start the Gunicorn web server
+  # Gunicorn cmd line flags:
+  # -w number of gunicorn worker processes
+  # -b IPADDR:PORT binding
+  # --access-logfile where to send HTTP access logs (- is stdout)
+  export GUNICORN_CMD_ARGS="-w 3 -b 0.0.0.0:8000 --access-logfile -"
+  cd "$APP_DIR"
+  gunicorn lbs.wsgi:application
+fi

--- a/lbs/lbs/settings.py
+++ b/lbs/lbs/settings.py
@@ -36,6 +36,8 @@ ALLOWED_HOSTS = list(os.getenv("DJANGO_ALLOWED_HOSTS").split(","))
 # Application definition
 
 INSTALLED_APPS = [
+    # Enable whitenoise in development per http://whitenoise.evans.io/en/stable/django.html
+    "whitenoise.runserver_nostatic",
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -47,6 +49,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -126,7 +129,16 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static'), ]
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+# There is a timing issue with Whitenoise that is described here:
+# https://github.com/evansd/whitenoise/issues/215
+# The work around suggested is to check for the existence of the
+# static root directory, and if doesn't exist yet then create it
+if not os.path.isdir(STATIC_ROOT):
+    os.makedirs(STATIC_ROOT, mode=0o755)
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field

--- a/lbs/requirements.txt
+++ b/lbs/requirements.txt
@@ -6,3 +6,5 @@ arrow==1.2.1
 python-tds==1.11.0
 openpyxl==3.0.9
 psycopg2==2.9.2
+gunicorn==20.1.0
+whitenoise==6.0.0


### PR DESCRIPTION
This PR adds, enables and configures two modules:
* gunicorn (a more robust alternative to the default `runserver`)
* whitenoise (manages static files well when paired with `gunicorn`)

Neither of these modules is intended for use during development.  A new script has been added, `docker_scripts/entrypoint.sh`, which performs different actions based on the run-time environment.  This script replaces the dev-only `runserver` in the Django image's `Dockerfile`.

This also adds automatic creation of a default `admin` Django superuser, in dev mode only, for convenience.  It can be used by developers, or ignored if you've already set up your own locally.

The changes are all infrastructure.  I've tested extensively locally, both with `DJANGO_RUN_ENV=dev` and `DJANGO_RUN_ENV=prod`.   But the easiest way to test locally:
* Pull and checkout branch `SYS-706/gunicorn`
* __Temporarily__ edit `docker_scripts/entrypoint.sh`, changing the `=` to `!=` on line 28
* `docker-compose up --build` - a fresh build is needed since `Dockerfile` changed
* Test the application as needed, watching the logs to make sure static files are served without 404 errors
* Shut down the application.  Note: if shutting down via CTRL-C, the Django container no longer shuts down cleanly, but exits with code 137.  The solution is to shut down with `docker-compose down` - or if CTRL-C was used, run `docker-compose down` afterwards anyhow.  `docker-compose ps` should show no running containers when done.
* __Revert__ the change to `docker_scripts/entrypoint.sh` on line 28

If all looks good, this PR can be merged.
