### PR TITLE
SYS-790: Allow email to be sent via the UI in any non-dev environment

### DIFF
--- a/lbs/qdb/views.py
+++ b/lbs/qdb/views.py
@@ -60,8 +60,8 @@ def report(request):
 
 
 def run_qdb_reporter(unit_from_form, month_from_form, year_from_form):
-    # suppress unneeded outputs on prod
-    if ENV == 'prod':  # pragma: no cover
+    # suppress unneeded outputs in non-dev environment(s)
+    if ENV != 'dev':  # pragma: no cover
         call_command('run_qdb_reporter', list_units=False, year=int(year_from_form),
                      month=int(month_from_form), units=[unit_from_form], email=True, list_recipients=False)
     # in dev, set list_units, list_recipients True for more information printed to the terminal


### PR DESCRIPTION
This tweaks the UI view for `/qdb/report/` to allow email to be sent in any non-dev environment (test, prod, whatever), to work around problems with the app as deployed in the kubertetes test environment, which was not accounted for with our binary `dev` or `prod` design.
