### PR TITLE
SYS-798: Improve control of email sending and recipient overrides

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -1,6 +1,6 @@
 ### Environment variables specific to the Django application ###
 
-# Can be 'dev' or 'prod' (this application defaults to 'dev' if this value not set)
+# Can be 'dev' or 'test' or prod' (this application defaults to 'dev' if this value not set)
 DJANGO_RUN_ENV=dev
 
 # 'Secret' key for dev only

--- a/README.md
+++ b/README.md
@@ -138,10 +138,8 @@ DJANGO_EMAIL_PASSWORD=your_email_password
 The reports are generated and/or emailed by a management script which can be either run automatically by the submitting the form in the qdb app or run manually on the command line. In the _prod_ environment (```DJANGO_RUN_ENV=prod```), the reports are emailed to the recipients listed in ```LBS_RECIPIENTS``` **and** they are emailed to staff matches in the _recipients_ table.
 
 Alternatively, in the _dev_ environment (DJANGO_RUN_ENV=dev), the reports are emailed to the recipients listed in ```DEV_RECIPIENTS``` **and** they are emailed to staff matches in the _recipients_ table.
-- The recipient email list may be overridden by setting the ```override_recipients``` argument in ``` views.py``` to one or more email addresses:
-```
-override_recipients=['email1@library.ucla.edu', 'email2@library.ucla.edu', ...]
-```
+- The recipient email list may be overridden by setting the ```override_recipients``` (command-line) or by entering one
+or more email addresses, separate by spaces, in the `Override recipients` text box in the UI.
 - When testing functionality from the command line, override recipients via the `-o` switch:
 ```
 # Example, testing current report
@@ -151,24 +149,6 @@ override_recipients=['email1@library.ucla.edu', 'email2@library.ucla.edu', ...]
 # -e: Send the report by email.  Only use when testing with -o override.
 python lbs/manage.py run_qdb_reporter -u 5 -r -o your@email.address -e
 ```
-
-__TODO: Refactor code so editing `views.py` is not needed__
-```
-Configure the ```else``` section around line 68 in ```views.py```
-- set ```email=True``` to enable sending of emails
-  - if ```email=False``` no emails are sent
-  - if ```email=False``` reports are stored in the server file system in lbs/qdb/reports/
-- set ```override_recipients``` to receive reports sent via email to your email address
-  -  ```override_recipients=['email1@library.ucla.edu', 'email2@library.ucla.edu', ...]```
-  - you must configure your own SMTP in ```.docker-compose_django.env```
-  - **use caution to avoid accidentally blasting reports to unsuspecting recipients**
-  - set ```email=False``` and read the recipient address in the terminal to check recipient list  before sending emails
-  - example config:
-
-```nano lbs/qdb/views.py```
-```
-        call_command('run_qdb_reporter', list_units=True, year=int(year_from_form),
-                     month=int(month_from_form), units=[unit_from_form], email=False, list_recipients=True, override_recipients=['youremail1@library.ucla.edu')]
 
 ```
 ---

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -26,7 +26,7 @@ if [ "$DJANGO_RUN_ENV" = "dev" ]; then
 fi
 
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then
-  python "$APP_DIR"/manage.py runserver 0.0.0.0:8000
+  PYTHONUNBUFFERED=1 python "$APP_DIR"/manage.py runserver 0.0.0.0:8000
 else
   # Build static files directory, starting fresh each time - do we really need this?
   python "$APP_DIR"/manage.py collectstatic --no-input

--- a/lbs/qdb/forms.py
+++ b/lbs/qdb/forms.py
@@ -32,3 +32,5 @@ class ReportForm(forms.Form):
         choices=YEARS, initial=year_default)
     month = forms.ChoiceField(
         choices=MONTHS, initial=month_default)
+    send_email = forms.BooleanField(required=False, initial=True)
+    override_recipients = forms.CharField(required=False)

--- a/lbs/qdb/scripts/orchestrator.py
+++ b/lbs/qdb/scripts/orchestrator.py
@@ -138,7 +138,6 @@ class Orchestrator():
             else:
                 recipients = self.get_recipients(unit_id, unit_name)
 
-            # set to True around line 68 in views.py to list recipients in the terminal
             if list_recipients is True:
                 print(f"\n{unit_name} recipients:")
                 for r in sorted(recipients):
@@ -162,7 +161,6 @@ class Orchestrator():
             filename = self.generate_filename(unit_name, yyyymm)
             formatter.generate_report(parser.data, filename)
 
-            # set to False around line 68 in _views.py_ to avoid sending email while working on the app
             if send_email is True:
                 sender.send_report(parser.data, filename, recipients)
                 os.remove(filename)

--- a/lbs/qdb/scripts/settings.py
+++ b/lbs/qdb/scripts/settings.py
@@ -1,7 +1,7 @@
 import os
 
 # Environment
-# Can be 'dev' or 'prod'
+# Can be 'dev', 'test' or 'prod' - default to 'dev'
 ENV = os.environ.get('DJANGO_RUN_ENV', 'dev')
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -12,7 +12,7 @@ SMTP_SERVER = os.environ['DJANGO_EMAIL_SMTP_SERVER']
 PORT = os.environ['DJANGO_EMAIL_SMTP_PORT']
 FROM_ADDRESS = os.environ['DJANGO_EMAIL_FROM_ADDRESS']
 PASSWORD = os.environ['DJANGO_EMAIL_PASSWORD']
-# akohler: Not sure this is important, but is used by SMTP call in sender.py
+# This is used by SMTP call in sender.py
 APP_IP = os.environ['DJANGO_APP_IP'] # The IP of the machine running this app
 
 # QDB server
@@ -36,7 +36,7 @@ SDLS_CONTACT_TITLE = "Head, Software Development & Library Systems"
 SLDS_CONTACT_EMAIL = "joshuagomez@library.ucla.edu"
 
 # Report Recipients
-# override by setting override_recipients in views.py
+# Used only when running tests
 TEST_RECIPIENT = os.environ.get('QDB_TEST_RECIPIENT', FROM_ADDRESS)
 
 DEV_RECIPIENTS = [
@@ -49,11 +49,11 @@ LBS_RECIPIENTS = [
     'jian@library.ucla.edu'  # Sandy Ma
 ]
 
-if ENV == 'prod':  # pragma: no cover
-    DEFAULT_RECIPIENTS = LBS_RECIPIENTS
-else:
+# akohler 20220414: test env will be treated like prod until rancher rebuild
+if ENV == 'dev':  # pragma: no cover
     DEFAULT_RECIPIENTS = DEV_RECIPIENTS
-
+else:
+    DEFAULT_RECIPIENTS = LBS_RECIPIENTS
 
 # Message strings
 MESSAGE_CLOSER = f'''

--- a/lbs/static/js/main.js
+++ b/lbs/static/js/main.js
@@ -7,6 +7,8 @@ const form = document.getElementById('p-form')
 const unit = document.getElementById('id_unit')
 const year = document.getElementById('id_year')
 const month = document.getElementById('id_month')
+const send_email = document.getElementById('id_send_email')
+const override_recipients = document.getElementById('id_override_recipients')
 const csrf = document.getElementsByName('csrfmiddlewaretoken')
 
 const url = ""
@@ -28,6 +30,8 @@ $(function () {
         formData.append('unit', unit.value)
         formData.append('year', year.value)
         formData.append('month', month.value)
+        formData.append('send_email', send_email.checked) // checkboxes are different!
+        formData.append('override_recipients', override_recipients.value)
 
         // display "long wait" warning if All units was specified
         var unit_selected = $("#id_unit option:selected").text();


### PR DESCRIPTION
This PR adds the ability to control whether email is sent, and whether override recipient(s) are used, via the UI at `/qdb/report/`.
* Adds 2 optional fields to the form in `forms.py`
  * `send_email` (checkbox, defaults to checked)
  *  `override_recipients` (text field, defaults to empty)
* Adds the new fields to `main.js` and its AJAX handling of the form data
* Adds handlers for these new fields to `views.py`
* Changes `views.py` to pass these new values to `run_qdb_reporter`
  * Also makes the call to `run_qdb_reporter` consistent, by setting parameters as needed according to the current environment
* Updates `README.md` to remove references to manually controlling this by editing `views.py`
* Changes comments about the environment to document `dev`, `test` and `prod`
* Changes how default recipients are set by treating `test` and `prod` the same, for now
* Updates entrypoint script to use unbuffered python output in `dev` environment, for more accurate log tailing
* Updates a few other comments

I've tested this pretty thoroughly, both in default `dev` and forced `test` environments.  It handles 0/1/2 override recipients; uses the correct `DEFAULT_RECIPIENTS` in both environments; sends email to all override recipients.  The only failure is sending email in `test` environment, which is correct since that uses UCLA SMTP which I can't access from home.

Please review; test as desired; let me know of any problems.