### PR TITLE
Adjust how external secrets annotations are defined

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for LBS Django applications, including QDB UI
 name: lbs
-version: 0.1.0
+version: 0.2.0

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -3,9 +3,10 @@ kind: ExternalSecret
 metadata:
   name: {{ include "lbs.fullname" . }}-externalsecrets
   namespace: lbs{{ .Values.django.env.run_env }}
+  {{- with .Values.django.externalSecrets.annotations }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   refreshInterval: 10m
   secretStoreRef:

--- a/charts/test-lbs-values.yaml
+++ b/charts/test-lbs-values.yaml
@@ -63,6 +63,9 @@ django:
 
   externalSecrets:
     enabled: "true"
+    annotations:
+      helm.sh/hook: "pre-install,pre-upgrade"
+      helm.sh/hook-delete-policy: "before-hook-creation"
     env:
       # Application database used by django
       db_password: "/systems/testsoftwaredev/lbstest/db_password"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -59,6 +59,9 @@ django:
 
   externalSecrets:
     enabled: "false"
+    annotations: {}
+      # helm weights and hooks - https://helm.sh/docs/topics/charts_hooks/
+      # argocd waves and hooks - https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
     env: {}
     # Include below if enabled: "true"
     #  db_password: ""


### PR DESCRIPTION
This is in preparation for migrating the LBS QDB app from the legacy rancher cluster to the new rancher cluster. 