### PR TITLE
SYS-146: Add logging

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -9,6 +9,9 @@ DJANGO_SECRET_KEY="django-insecure-*2#@x%#ladb71pm)ldwrtwk63fnzfi(luz(a@5n@m54k*
 # For dev only
 DJANGO_DEBUG=True
 
+# DEBUG, INFO, WARNING, ERROR, CRITICAL
+DJANGO_LOG_LEVEL=DEBUG
+
 # Comma separated list of allowed hosts
 # https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]

--- a/README.md
+++ b/README.md
@@ -207,3 +207,10 @@ After first login, register the local database server.
   * Click `Save`, without changing any other settings
 
 See [pgAdmin documentation](https://www.pgadmin.org/docs/) for more information.
+
+## Viewing the log
+Local development environment: `view logs/application.log`.
+
+In deployed container:
+* `/logs/`: see latest 200 lines of the log
+* `/logs/nnn`: see latest `nnn` lines of the log

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for LBS Django applications, including QDB UI
 name: lbs
-version: 0.3.2
+version: 0.3.3

--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -39,6 +39,7 @@ django:
   env:
     run_env: "prod"
     debug: "false"
+    log_level: "INFO"
     allowed_hosts:
       - lbs.library.ucla.edu
     csrf_trusted_origins:

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
   DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}
   DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
   DJANGO_CSRF_TRUSTED_ORIGINS: {{ range .Values.django.env.csrf_trusted_origins }}{{ . | quote }}{{ end }}
   DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -33,6 +33,7 @@ django:
   env:
     run_env: "prod"
     debug: "false"
+    log_level: ""
     allowed_hosts: []
     #  - localhost
     #  - 127.0.0.1

--- a/ge/models.py
+++ b/ge/models.py
@@ -140,3 +140,6 @@ class LibraryData(models.Model):
     fund_restriction = models.CharField(max_length=1000, null=True)
     new_fund = models.CharField(max_length=1, null=True)
     lbs_notes = models.CharField(max_length=1000, null=True)
+
+    def __str__(self):
+        return f"{self.fund_title}: {self.fau_account}-{self.fau_cost_center}-{self.fau_fund}"

--- a/ge/templates/ge/log.html
+++ b/ge/templates/ge/log.html
@@ -1,0 +1,8 @@
+{% extends 'ge/base.html' %}
+
+{% block content %}
+<h3>Super QAD Log Dumper</h3>
+<pre>
+{{ log_data }}
+</pre>
+{% endblock %}

--- a/ge/urls.py
+++ b/ge/urls.py
@@ -4,4 +4,6 @@ from . import views
 urlpatterns = [
     path("ge/report/", views.report),
     path("", views.report),
+    path("logs/", views.show_log, name="show_log"),
+    path("logs/<int:line_count>", views.show_log, name="show_log"),
 ]

--- a/ge/views.py
+++ b/ge/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from ge.forms import ExcelUploadForm
@@ -32,3 +32,19 @@ def report(request: HttpRequest):
         form = ExcelUploadForm()
     context = {"form": form}
     return render(request, "ge/ge_report.html", context)
+
+
+@login_required(login_url="/login/")
+def show_log(request, line_count: int = 200) -> HttpResponse:
+    log_file = "logs/application.log"
+    try:
+        with open(log_file, "r") as f:
+            # Get just the last line_count lines in the log.
+            lines = f.readlines()[-line_count:]
+            # Template prints these as a single block, so join lines into one chunk.
+            log_data = "".join(lines)
+    except FileNotFoundError:
+        log_data = f"Log file {log_file} not found"
+
+    # TODO: Move / unify templates across ge and qdb apps
+    return render(request, "ge/log.html", {"log_data": log_data})

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -1,6 +1,9 @@
+import logging
 from django.db.models import Model
 from pandas import read_excel
 from ge.models import BFSImport, CDWImport, LibraryData, MTFImport
+
+logger = logging.getLogger(__name__)
 
 
 def import_excel_data(excel_file: str, model: Model) -> None:
@@ -221,24 +224,21 @@ def add_funds() -> None:
 
             else:
                 # No matching BFSImport row found, so log a message.
-                # TODO: Logging!
-                print(
-                    f"Warning: No matching BFS (consolidated) data found for {new_fund.fau_fund=}"
+                logger.warning(
+                    f"No matching BFS (consolidated) data found for {new_fund.fau_fund=}"
                 )
 
             # Original Access query qryAddNew_8:
             # Clear the "new_fund" flag.
-            # TODO: Disabled while reviewing data.
-            # new_fund.new_fund = "N"
+            new_fund.new_fund = "N"
 
             # Finally, save the new LibraryData record.
+            logger.info(f"Added fund: {new_fund}")
             new_fund.save()
 
 
 def update_data() -> None:
     """Update LibraryData rows to final state before report generation."""
-
-    # TODO: Replace print statements with proper logging.
 
     # Original Access query qryAAA_0Clear:
     # Set several financial values to 0 for all rows.
@@ -251,7 +251,7 @@ def update_data() -> None:
         projected_annual_income=0,
         total_fund_value=0,
     )
-    print(f"qryAAA_0Clear: {cnt} updated")
+    logger.info(f"qryAAA_0Clear: {cnt} updated")
 
     # Original Access query qryAAA_1UpdateMTF (and duplicate qryAAA_1UpdateMTF1):
     # Update relevant LibraryData rows from MTF data (first matching row only, if any).
@@ -265,7 +265,7 @@ def update_data() -> None:
                 ld.max_mtf_trf_amt = mtf.max_transfer_balance
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_1UpdateMTF: {cnt} updated")
+    logger.info(f"qryAAA_1UpdateMTF: {cnt} updated")
 
     # Original Access query qryAAA_2ProjIncomFound:
     # Update projected annual income from BFS data (Foundation funds).
@@ -278,7 +278,7 @@ def update_data() -> None:
                 ld.projected_annual_income = bfs.projected_income
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_2ProjIncomFound: {cnt} updated")
+    logger.info(f"qryAAA_2ProjIncomFound: {cnt} updated")
 
     # Original Access query qryAAA_2ProjIncomReg:
     # Update projected annual income from BFS data (Regental funds).
@@ -291,7 +291,7 @@ def update_data() -> None:
                 ld.projected_annual_income = bfs.projected_income
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_2ProjIncomReg: {cnt} updated")
+    logger.info(f"qryAAA_2ProjIncomReg: {cnt} updated")
 
     # Original Access query qryAAA_3FoundTotVal:
     cnt = 0
@@ -306,7 +306,7 @@ def update_data() -> None:
                 ld.total_fund_value = bfs.market_value
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3FoundTotVal: {cnt} updated")
+    logger.info(f"qryAAA_3FoundTotVal: {cnt} updated")
 
     # Original Access query qryAAA_3FoundTotVal_2:
     cnt = 0
@@ -321,7 +321,7 @@ def update_data() -> None:
                 ld.total_fund_value = ld.total_fund_value + bfs.available
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3FoundTotVal_2: {cnt} updated")
+    logger.info(f"qryAAA_3FoundTotVal_2: {cnt} updated")
 
     # Original Access query qryAAA_3FoundTotVal_3:
     # This currently matches no rows; asking LBS if this is correct.
@@ -338,7 +338,7 @@ def update_data() -> None:
                 ld.total_fund_value = ld.total_fund_value - bfs.unavailable
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3FoundTotVal_3: {cnt} updated")
+    logger.info(f"qryAAA_3FoundTotVal_3: {cnt} updated")
 
     # Original Access query qryAAA_3RegTotVal:
     # Regental fund math is different from Foundation math above...
@@ -354,7 +354,7 @@ def update_data() -> None:
                 ld.total_fund_value = bfs.available
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3RegTotVal: {cnt} updated")
+    logger.info(f"qryAAA_3RegTotVal: {cnt} updated")
 
     # Original Access query qryAAA_3RegTotVal_2:
     # Regental fund math is different from Foundation math above...
@@ -370,7 +370,7 @@ def update_data() -> None:
                 ld.total_fund_value = ld.total_fund_value - bfs.unavailable
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3RegTotVal_2: {cnt} updated")
+    logger.info(f"qryAAA_3RegTotVal_2: {cnt} updated")
 
     # Original Access query qryAAA_3RegTotVal_3:
     # Regental fund math is different from Foundation math above...
@@ -386,7 +386,7 @@ def update_data() -> None:
                 ld.total_fund_value = ld.total_fund_value + bfs.market_value
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3RegTotVal_3: {cnt} updated")
+    logger.info(f"qryAAA_3RegTotVal_3: {cnt} updated")
 
     # Original Access query qryAAA_3RegTotVal_4:
     # Regental fund math is different from Foundation math above...
@@ -403,7 +403,7 @@ def update_data() -> None:
                 ld.total_fund_value = bfs.available
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_3RegTotVal_4: {cnt} updated")
+    logger.info(f"qryAAA_3RegTotVal_4: {cnt} updated")
 
     # Original Access query qryAAA_5_5400:
     # Update LibraryData amounts from CDW data.
@@ -423,7 +423,7 @@ def update_data() -> None:
                 ld.operating_balance = cdw.operating_balance
                 ld.save()
                 cnt += 1
-    print(f"qryAAA_5_5400: {cnt} updated")
+    logger.info(f"qryAAA_5_5400: {cnt} updated")
 
     # Original Access query qryAAA_6TotalBalance:
     # Finally, update LibraryData total balance for all rows.
@@ -432,4 +432,4 @@ def update_data() -> None:
         ld.total_balance = ld.operating_balance + ld.max_mtf_trf_amt
         ld.save()
         cnt += 1
-    print(f"qryAAA_6TotalBalance: {cnt} updated")
+    logger.info(f"qryAAA_6TotalBalance: {cnt} updated")

--- a/lbs/settings.py
+++ b/lbs/settings.py
@@ -178,3 +178,33 @@ MESSAGE_TAGS = {
 # uses smtplib directly, bypassing Django
 # But this will be helpful if/when that code is updated to use Django.
 EMAIL_BACKEND = os.getenv("DJANGO_EMAIL_BACKEND")
+
+# Logging
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {name} {module} {message}",
+            # Shortcut for str.format()
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+        "file": {
+            "class": "logging.FileHandler",
+            "filename": "./logs/application.log",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        # Unnamed logger should capture from all loggers
+        "": {
+            "handlers": ["file"],
+            "level": os.getenv("DJANGO_LOG_LEVEL"),
+        },
+    },
+}

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/qdb/scripts/fetcher.py
+++ b/qdb/scripts/fetcher.py
@@ -87,5 +87,4 @@ def get_qdb_data(yyyymm, account_number, cc_codes):
         # Run query with the other, real, parameters
         cursor.execute(qdb_final_query % (yyyymm, account_number))
         rows = cursor.fetchall()
-        # print(f'DEBUG: {account_number} in {yyyymm} found {len(rows)} rows')
         return rows

--- a/qdb/views.py
+++ b/qdb/views.py
@@ -1,14 +1,17 @@
+import json
+import logging
 from django.http import HttpRequest
 from django.shortcuts import render
 from django.http.response import HttpResponse
 from django.core.management import call_command
 from django.contrib.auth.views import logout_then_login
 from django.contrib.auth.decorators import login_required
-import json
 from .forms import ReportForm
 from django.contrib import messages
 from django.utils.html import format_html
 from qdb.scripts.settings import ENV
+
+logger = logging.getLogger(__name__)
 
 
 @login_required(login_url="/login/")
@@ -19,6 +22,7 @@ def report(request):
     # https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpRequest.is_ajax
     # TODO: Is this ajax check really needed?
     if request.headers.get("x-requested-with") == "XMLHttpRequest":
+        # TODO: submitbutton is never used explicitly; why is "submit" checked here?
         submitbutton = request.POST.get("submit")
         form = ReportForm(request.POST or None)
         if form.is_valid():
@@ -36,28 +40,33 @@ def report(request):
                 override_recipients = override_recipients.split()
 
             try:
-                report = run_qdb_reporter(
-                    unit, month, year, send_email, override_recipients
-                )
+                run_qdb_reporter(unit, month, year, send_email, override_recipients)
                 messages.success(
                     request, "QDB report successfully generated.", extra_tags=unit_name
                 )
             except Exception as e:
-                print(str(e))
-                if "Login failed for user" in str(e):
+                exception_message = str(e)
+                logger.error(exception_message)
+                if "Login failed for user" in exception_message:
                     messages.error(
                         request,
                         format_html(
-                            "Remote database not available: no report could be generated.<br>-----<br>Please try again later as this may be due to routine maintenance.<br>Note: Middle-of-the-night maintenance can take up to 60 minutes"
+                            "Remote database not available: no report could be generated."
+                            "<br>-----"
+                            "<br>Please try again later as this may be due to routine maintenance."
+                            "<br>Note: Middle-of-the-night maintenance can take up to 60 minutes"
                         ),
                         extra_tags=unit_name,
                     )
-                elif "timed out" in str(e):
+                elif "timed out" in exception_message:
                     # apply escaping to (unsafe) html with format_html
                     messages.error(
                         request,
                         format_html(
-                            'Network problem: no report could be generated.<br>-----<br>Please use the <a href="https://www.it.ucla.edu/it-support-center/services/virtual-private-network-vpn-clients">UCLA VPN</a> when off campus.<br><a href="https://uclalibrary.github.io/research-tips/get-configured/">Help with VPN</a> (tutorials on how to connect).'
+                            "Network problem: no report could be generated."
+                            "<br>-----"
+                            "<br>Please use the <a href='https://www.it.ucla.edu/it-support-center/services/virtual-private-network-vpn-clients'>UCLA VPN</a> when off campus."
+                            "<br><a href='https://uclalibrary.github.io/research-tips/get-configured/'>Help with VPN</a> (tutorials on how to connect)."
                         ),
                         extra_tags=unit_name,
                     )
@@ -65,7 +74,11 @@ def report(request):
                     messages.error(
                         request,
                         format_html(
-                            'Error: no report could be generated.<br>-----<br>Please report this to the DIIT Help Desk:<br><a href="https://jira.library.ucla.edu/servicedesk/customer/portals">UCLA Library Service Portal</a>'
+                            "Error: no report could be generated."
+                            "<br>-----"
+                            "<br>Please report this to the DIIT Help Desk:"
+                            "<br><a href='https://uclalibrary.atlassian.net/servicedesk/customer/portals'>"
+                            "UCLA Library Service Portal</a>"
                         ),
                         extra_tags=unit_name,
                     )


### PR DESCRIPTION
Implements [SYS-146](https://uclalibrary.atlassian.net/browse/SYS-146).  Internal only, not tagged for deployment.

This PR adds support for logging, using the basic default logging framework we've used with our other Django applications.  It also replaces most `print()` statements with relevant logging commands.  A few `print()` statements remain, as they're intended for output when running as a command-line application when testing as a developer.

Summary of changes:
* Set `DJANGO_LOG_LEVEL` to `DEBUG` in dev environment, `INFO` in deployed environment
  * This required changes to the overall Helm chart, so that version was incremented for our chart museum.
* Added basic info about viewing the log to `README.md`
* Added view/template/route for viewing logs in the application
* Added `__str__()` to the `LibraryData` model for useful output when printing/logging of those objects
* Did a little reformatting & refactoring of legacy `qdb/views.py` while adding logging statements

For now, the log view is not added to the application UI.  The whole template system needs some reworking to unify appearance and to add navigation between `ge` and `qdb` apps, which we'll do via new ticket(s).

### Testing
1. Restart the application, to apply the new settings which enable & configure logging.
2. Visit http://127.0.0.1:8000/ge/report/ , upload files.
3. Visit http://127.0.0.1:8000/logs/ to confirm logging messages appear
4. Output will vary, but should contain about a dozen messages like
```
INFO 2023-10-19 12:31:08,829 ge.views_utils views_utils qryAAA_5_5400: 449 updated
INFO 2023-10-19 12:31:09,452 ge.views_utils views_utils qryAAA_6TotalBalance: 607 updated
```


[SYS-146]: https://uclalibrary.atlassian.net/browse/SYS-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ