### PR TITLE
SYS-1438: Add zip export and more

### DIFF
--- a/ge/forms.py
+++ b/ge/forms.py
@@ -25,9 +25,11 @@ class LibraryDataSearchForm(forms.Form):
     search_types = [
         ("fund", "Fund"),
         ("keyword", "Title / Notes"),
+        ("unit", "Unit"),
+        ("new_funds", "New Funds"),
     ]
     search_type = forms.ChoiceField(choices=search_types, initial="fund")
-    search_term = forms.CharField(label="Search for")
+    search_term = forms.CharField(label="Search for", required=False)
 
 
 class LibraryDataEditForm(forms.ModelForm):
@@ -44,6 +46,8 @@ class LibraryDataEditForm(forms.ModelForm):
             "notes": forms.Textarea(attrs={"cols": 80, "rows": 2}),
             # Wider single-line text fields
             "fund_title": forms.TextInput(attrs={"size": 80}),
+            # Number field which doesn't need a number widget
+            "original_id": forms.TextInput(),
         }
 
 

--- a/ge/templates/ge/ge_report.html
+++ b/ge/templates/ge/ge_report.html
@@ -29,11 +29,14 @@
 <br>
 <hr>
 <br>
-<p>Select a report to generate and download it to your computer.</p>
+<p>Select a report to generate and download it to your computer.
+  <br>
+Or download all reports in one zip file (takes about 30-40 seconds).</p>
 <form id="get_report" method="get" name="get_report">
   {% csrf_token %}
   {{ report_form.as_p }}
   <button type="submit" name="report_submit">Get report</button>
+  <button type="submit" name="download_zip_submit">Download all reports</button>
  </form>
  
 {% endblock %}

--- a/ge/templates/ge/ge_report.html
+++ b/ge/templates/ge/ge_report.html
@@ -9,13 +9,27 @@
 {% endfor %}
 </div>
 {% endif %}
-
+<br>
 <form id="upload_files" method="post" enctype="multipart/form-data">
     {% csrf_token %}
-    {{ upload_form.as_p }}
+    <table class="upload-form">
+      {% for field in upload_form %}
+      <tr>
+        <td>
+          <div class="tooltip">{{ field.label_tag }}
+            <span class="tooltiptext">{{ field.help_text|safe }}</span>
+          </div>
+        </td>
+        <td>{{ field }}</td>
+      </tr>
+      {% endfor %}
+    </table>
     <button type="submit" id="upload_submit" >Upload files</button>
 </form>
-
+<br>
+<hr>
+<br>
+<p>Select a report to generate and download it to your computer.</p>
 <form id="get_report" method="get" name="get_report">
   {% csrf_token %}
   {{ report_form.as_p }}

--- a/ge/templates/ge/ge_search.html
+++ b/ge/templates/ge/ge_search.html
@@ -10,6 +10,7 @@
 </div>
 {% endif %}
 
+<p>Select a search type and enter a word or phrase to search for.  For new funds, leave "Search for" empty.</p>
 <form id="search" method="post">
     {% csrf_token %}
     {{ form.as_p }}
@@ -17,6 +18,7 @@
 </form>
 
 {% if results %}
+<p>Your search found {{ results|length }} records.</p>
 <hr>
 <table class="search-results">
     <thead>

--- a/ge/tests.py
+++ b/ge/tests.py
@@ -242,6 +242,10 @@ class SearchLibraryDataTestCase(TestCase):
         results = get_librarydata_results(search_type="keyword", search_term="FY23")
         self.assertEqual(len(results), 3)
 
+    def test_unit_search_results(self):
+        results = get_librarydata_results(search_type="unit", search_term="studies")
+        self.assertEqual(len(results), 2)
+
     def test_search_is_case_insensitive(self):
         # Data in record is "Ludwig"; should find "ludwig"
         results = get_librarydata_results(search_type="keyword", search_term="ludwig")
@@ -258,4 +262,11 @@ class SearchLibraryDataTestCase(TestCase):
         results = get_librarydata_results(
             search_type="keyword", search_term="akohler test"
         )
+        self.assertEqual(len(results), 1)
+
+    def test_new_funds_are_found(self):
+        # Per notes in AddFundsTestCase.test_correct_new_fund_is_added(),
+        # only one new fund is added from our test data.
+        add_funds()
+        results = get_librarydata_results(search_type="new_funds", search_term="")
         self.assertEqual(len(results), 1)

--- a/ge/views.py
+++ b/ge/views.py
@@ -11,10 +11,11 @@ from ge.forms import (
 from ge.models import BFSImport, CDWImport, LibraryData, MTFImport
 from ge.views_utils import (
     add_funds,
+    download_excel_file,
+    download_zip_file,
     get_librarydata_results,
     import_excel_data,
     update_data,
-    create_excel_output,
 )
 
 
@@ -44,7 +45,9 @@ def report(request: HttpRequest):
     elif "report_submit" in request.GET:
         report_form = ReportForm(request.GET)
         if report_form.is_valid():
-            return create_excel_output(request.GET.get("report_type"))
+            return download_excel_file(request.GET.get("report_type"))
+    elif "download_zip_submit" in request.GET:
+        return download_zip_file()
     else:
         upload_form = ExcelUploadForm()
         report_form = ReportForm()

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse
 from openpyxl import load_workbook
 from openpyxl.utils import get_column_letter
 from openpyxl.utils.dataframe import dataframe_to_rows
+from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from os import path
 from tempfile import NamedTemporaryFile
@@ -564,8 +565,11 @@ def df_to_excel(df: pd.DataFrame, ws: Worksheet) -> Worksheet:
     return ws
 
 
-def create_excel_output(rpt_type: str) -> HttpResponse:
-    """Create Excel output for a report."""
+def create_excel_output(rpt_type: str) -> Workbook:
+    """Create Excel output for a report.
+
+    Returns a Workbook, for direct download or archiving as needed.
+    """
 
     # UL and Master reports have extra columns, so use a different template
     if rpt_type in ("master", "ul"):
@@ -849,8 +853,15 @@ def create_excel_output(rpt_type: str) -> HttpResponse:
             # Projected Annual Income col is Q on non-UL endowments reports
             endowments_ws["Q3"] = as_of
 
+    return wb
+
+
+def download_excel_file(rpt_type: str) -> HttpResponse:
+    """Get Excel file via HTTP response."""
+    workbook = create_excel_output(rpt_type)
+
     with NamedTemporaryFile() as tmp:
-        wb.save(tmp.name)
+        workbook.save(tmp.name)
         tmp.seek(0)
         stream = tmp.read()
 
@@ -863,3 +874,10 @@ def create_excel_output(rpt_type: str) -> HttpResponse:
     ] = f'attachment; filename={rpt_type}-Report-{datetime.now().strftime("%Y%m%d%H%M")}.xlsx'
 
     return response
+
+
+def download_zip_file() -> HttpResponse:
+    """Get zip file containing all Excel reports, via HTTP response."""
+    # iterate over all reports, get excel output for each, add to zip, download zip
+
+    return HttpResponse("ZIP FILE GOES HERE")

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -3,7 +3,6 @@ import logging
 from django.db.models import Model, Q
 import pandas as pd
 from datetime import datetime
-from django.db.models import Model
 from django.http import HttpResponse
 from openpyxl import load_workbook
 from openpyxl.utils import get_column_letter
@@ -486,7 +485,8 @@ def get_librarydata_results(search_type: str, search_term: str) -> list[LibraryD
 
     # Search logic is different for new funds
     if search_type == "new_funds":
-        # Look for empty fields.
+        # Look for empty fields, overriding search_term if supplied.
+        search_term = ""
         q_list = [Q(**{field + "__exact": search_term}) for field in fields_to_search]
         # AND them all together.
         q_filter = reduce(lambda a, b: a & b, q_list)
@@ -529,7 +529,9 @@ def get_last_col(ws: Worksheet, row: int) -> int:
 
 
 def get_as_of_date(date: datetime = datetime.now()) -> str:
-    """Get the as-of label for use in column headers, defined as the last day of the previous period."""
+    """Get the as-of label for use in column headers,
+    defined as the last day of the previous quarter.
+    """
     current_month = date.month
     # Jan - Mar
     if current_month <= 3:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -14,7 +14,7 @@ a:link, a:visited {
     vertical-align: top;
 }
 
-.data-form {
+.data-form td {
     border-collapse: collapse;
     border: none;
     vertical-align: top;
@@ -22,6 +22,7 @@ a:link, a:visited {
 
 .data-form th {
     text-align: right;
+    vertical-align: top;
 }
 
 ul.navbar {
@@ -44,4 +45,24 @@ ul.navbar {
     text-align: center;
     padding: 10px 12px;
     text-decoration: none;
+}
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    background-color: black;
+    color: white;
+    text-align: center;
+    padding: 5px;
+    border-radius: 6px;
+    position: fixed;
+    z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
 }


### PR DESCRIPTION
Implements [SYS-1438](https://uclalibrary.atlassian.net/browse/SYS-1438) and various odds and ends.  Internal only, not tagged for release.

This PR primarily adds the ability to download all Excel reports in one zip file, via the cleverly-named "Download all reports" button on `/ge/report/`.  I refactored `create_excel_output()` to separate creation of an Excel workbook from the HTTP response.  Conversion of the workbook to bytes for output is pulled into `get_bytes_from_workbook()`.  Adding a single Excel file to HTTP response is done via `download_excel_file()`, and iterating over all reports and building / returning a zip archive is done via `download_zip_file()`.

The zip archive uses the list of all reports provided by the choices in `ReportForm()`, so adding new reports there (and to the mapping in `create_excel_output()`) will automatically get them included in the zip archive.

The PR also includes small enhancements from today's meeting:
* The search form now supports search by unit.
* The search form now supports search for new funds (defined as those with nothing in `unit` and nothing in `fund_manager`, to avoid existing "spare rows").
  * The search term box can now be left empty (since not relevant for new fund search), but search terms will be ignored for new fund search anyhow.
* Added number of records found to the search results page.
* Added tests for the new searches.
* Tweaked CSS to align labels with the top of table cells in the `LibraryData` edit form.
* Changed `LibraryDataEditForm.original_id` widget to use text input, instead of the default number input widget.
* Added tooltips to the field for the Excel upload form (via HTML and CSS), to help identify what `BFS/CDW/MFT` mean.
* Possibly other minor tweaks / incidental code & comment cleanup.

### Testing
`docker-compose exec django python manage.py test` should run 56 tests, all passing.

Go to http://127.0.0.1:8000/ge/search/ and try the new searches (Unit and New Funds).

Manual testing currently is needed for the zip file output.  Go to http://127.0.0.1:8000/ge/report/ , click the "Download all reports" button, wait 30-40 seconds.  Depending on personal browser settings, you'll either be prompted to accept a zip file download, or it will automatically download into your designated directory.

Contents of the zip file should look similar to the screenshot below.  Unzip it, or click on files within it as allowed by your OS, to confirm that these really are reports and they look correct.

![ge_reports_zip_contents](https://github.com/UCLALibrary/LBS/assets/2213836/094328f8-0177-4398-b5df-e081e911b7e7)
