### PR TITLE
SYS-1450: Initial GE reports deployment

### DIFF
--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.0.7
+  tag: 1.1.0
   pullPolicy: Always
 
 nameOverride: ""

--- a/qdb/templates/form.html
+++ b/qdb/templates/form.html
@@ -9,6 +9,8 @@
     <div id="header">
         <div id="branding">
             <h1 id="site-name"><a href="/admin/">QDB Reports</a></h1>
+            <h1>|</h1>
+            <h1 id="site-name"><a href="/ge/report/">GE Reports</a></h1>
         </div>
         <div id="user-tools">
             Welcome,

--- a/qdb/templates/release_notes.html
+++ b/qdb/templates/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.0</h4>
+<p><i>November 9, 2023</i></p>
+<ul>
+    <li>Added Gifts & Expenditures (GE) reporting application.</li>
+</ul>
+
 <h4>1.0.7</h4>
 <p><i>September 22, 2023</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-1450](https://uclalibrary.atlassian.net/browse/SYS-1450).  Version set to `1.1.0` for deployment.

This PR contains a minor tweak to the QDB template header, adding a link to the new GE Reports.  It also adds release notes for this version.


[SYS-1450]: https://uclalibrary.atlassian.net/browse/SYS-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ