### PR TITLE
SYS-1451: Make GE and QDB apps more consistent with each other

### DIFF
--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/ge/templates/ge/base.html
+++ b/ge/templates/ge/base.html
@@ -1,9 +1,11 @@
 {% load static %}
 <html>
     <head>
+        <title>GE Report</title>
         <!-- Custom CSS -->
         <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
-        <title>GE Report</title>
+        <!-- Favicon -->
+        <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
     </head>
     <body>
         <ul class="navbar">
@@ -11,7 +13,7 @@
             <li><a href="/ge/report/">GE Reports</a></li>
             <li><a href="/qdb/report/">QDB Reports</a></li>
             <li><a href="/logs/">Logs</a></li>
-            <li><a href="/qdb/release_notes/">Release Notes</a></li>
+            <li><a href="/release_notes/">Release Notes</a></li>
             <li><a href="/qdb/logout/">Logout</a></li>
         </ul>
         <br>

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'ge/base.html' %}
 
 {% block content %}
 <h3>Release Notes</h3>

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,6 +4,15 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.1</h4>
+<p><i>November 16, 2023</i></p>
+<ul>
+    <li>Upgraded Django from version 4.2.5 to 4.2.7.</li>
+    <li>Cleaned up login and logout to be more consistent across GE and QDB apps.</li>
+    <li>Moved release notes template to GE app, with neutral path (/release_notes/).</li>
+    <li>Made favicon usage consistent across apps.</li>
+</ul>
+
 <h4>1.1.0</h4>
 <p><i>November 9, 2023</i></p>
 <ul>

--- a/ge/urls.py
+++ b/ge/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("ge/edit/<int:item_id>", views.edit_librarydata, name="edit_librarydata"),
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
+    path("release_notes/", views.release_notes, name="release_notes"),
 ]

--- a/ge/views.py
+++ b/ge/views.py
@@ -21,7 +21,7 @@ from ge.views_utils import (
 
 # TODO: Clean up auth system across qdb/ge apps
 @login_required(login_url="/login/")
-def report(request: HttpRequest):
+def report(request: HttpRequest) -> HttpResponse:
     if request.method == "POST":
         upload_form = ExcelUploadForm(request.POST, request.FILES)
         # Make sure report_form is initialized, for later use.
@@ -98,3 +98,8 @@ def edit_librarydata(request: HttpRequest, item_id: int) -> HttpResponse:
     else:
         form = LibraryDataEditForm(instance=record)
     return render(request, "ge/edit_item.html", {"form": form})
+
+
+@login_required(login_url="/login/")
+def release_notes(request: HttpRequest) -> HttpResponse:
+    return render(request, "ge/release_notes.html")

--- a/lbs/settings.py
+++ b/lbs/settings.py
@@ -163,7 +163,8 @@ STORAGES = {
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-LOGOUT_REDIRECT_URL = "/admin"
+LOGIN_URL = "/qdb/report/"
+LOGOUT_REDIRECT_URL = "/"
 
 MESSAGE_TAGS = {
     messages.DEBUG: "alert-secondary",

--- a/qdb/templates/registration/login.html
+++ b/qdb/templates/registration/login.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en-us" dir="ltr">
     <head>
-        <title>Log in | QDB</title>
+        <title>Log in | LBS</title>
 
         <!-- Required meta tags -->
         <meta charset="utf-8">
@@ -27,7 +27,7 @@
         <script src="{% static 'js/main.js' %}" defer></script>
     
         <!-- Favicon -->
-        <link rel="shortcut icon" href="https://www.library.ucla.edu/sites/all/themes/uclalib_omega/favicon.ico" type="image/vnd.microsoft.icon" />
+        <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
     </head>
 
     <body class=" login"
@@ -38,7 +38,7 @@
         <!-- Header -->
         <div id="header">
             <div id="branding">
-                <h1 id="site-name"><a href="/qdb/report/">Log in | QDB</a></h1>
+                <h1 id="site-name">LBS Log in: <a href="/qdb/report/">QDB</a> | <a href="/ge/report/">GE</a></h1>
             </div>
         </div>
         <!-- END Header -->

--- a/qdb/urls.py
+++ b/qdb/urls.py
@@ -4,6 +4,5 @@ from . import views
 urlpatterns = [
     path("qdb/report/", views.report),
     path("qdb/logout/", views.logoutandlogin),
-    path("qdb/release_notes/", views.release_notes, name="release_notes"),
     path("", views.report),
 ]

--- a/qdb/views.py
+++ b/qdb/views.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_required(login_url="/login/")
-def report(request):
+def report(request: HttpRequest) -> HttpResponse:
     # This was originally "if request.is_ajax()"... which was deprecated
     # with Django 3.1, removed in 4.0.
     # For now I'm going with the equivalent, per
@@ -132,8 +132,4 @@ def run_qdb_reporter(
 
 
 def logoutandlogin(request):
-    return logout_then_login(request, login_url="/qdb/report/")
-
-
-def release_notes(request: HttpRequest) -> HttpResponse:
-    return render(request, "release_notes.html")
+    return logout_then_login(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow==1.2.3
 asgiref==3.7.2
-Django==4.2.5
+Django==4.2.7
 gunicorn==21.2.0
 openpyxl==3.1.2
 pandas==2.1.1


### PR DESCRIPTION
Implements [SYS-1451 (login-related refactoring)](https://uclalibrary.atlassian.net/browse/SYS-1451) and [SYS-1456 (apply Django 4.2.7 security upgrade)](https://uclalibrary.atlassian.net/browse/SYS-1456).  Tagged as version `1.1.1` for deployment.

This PR is a mixture of changes, mostly related to attempting to make the GE and QDB applications more consistent in how they use login & logout.  This involved template changes, which led to broader template cleanup, while preserving the current visual distinction between the apps.  Generally:

* The default application is still QDB, mainly because it's used monthly while GE is used quarterly.
* The login screen now has (subtle) links to GE and QDB apps.  If the user clicks one before actually logging in, they'll wind up at the main report page for the app they chose.
* Logging out no longer redirects to a Django admin-related page, but just to the generic `/`.
* Release notes template moved from QDB to GE, to be consistent with the Logs template.
* Release notes URL changed to be generic `/release_notes/`, similar to generic `/logs/` URL.
* Both GE and QDB apps now use a `favicon.ico` file consistently, local to the application instead of pulled via HTTP from the now-defunct Drupal main library site
* Added a few type hints to views.
* Upgraded Django from 4.2.5 to 4.2.7 (latest released) to address some security issue.  I reviewed the release notes and confirmed no changes affect this project.

### Testing

I decided not to add any automated tests, as we don't make any distinctions between access to GE and QDB.  All views are wrapped in the standard Django `@login_required` decorator, and we don't need to test that built-in functionality.

Please do some brief manual testing:
* Restart the application to apply settings changes and to upgrade Django.
* Visit http://127.0.0.1:8000
* Click [QDB](http://127.0.0.1:8000/qdb/report/) and log in, confirming you arrive at the QDB Reports page.
* Logout via the link at far right of the QDB navigation bar.
* You'll be back at the login screen, though the URL now points to `/login/?next=/qdb/report/`
* Click [GE](http://127.0.0.1:8000/ge/report/) and log in, confirming you arrive at the GE Reports page.
* Click through the various links in the GE navigation bar, confirming they all work and all (except QDB Reports) have the same navigation bar.

Thanks --Andy