### PR TITLE
SYS-1469: Add FTVA to GE Reports

### DIFF
--- a/ge/forms.py
+++ b/ge/forms.py
@@ -61,6 +61,7 @@ class ReportForm(forms.Form):
             ("biomed", "Biomed"),
             ("digilib", "Digital Library"),
             ("eal", "East Asian Library"),
+            ("ftva", "Film & TV Archive"),
             ("hsc", "History & SC Sciences"),
             ("hssd", "HSSD"),
             ("ias", "Intl & Area Studies"),

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -652,6 +652,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
             "biomed": ["Biomed"],
             "digilib": ["DigiLib", "Digital Library"],
             "eal": ["EAL"],
+            "ftva": ["FTVA"],
             "hsc": ["History & SC Sciences"],
             "hssd": ["HSSD", "SSHD"],
             "ias": ["Int'l Studies"],


### PR DESCRIPTION
Implements [SYS-1469](https://uclalibrary.atlassian.net/browse/SYS-1469)

Very small change to add the FTVA report. We didn't have a query or sample reports for this one, but it uses the standard Library report template and retrieves rows with `unit` value `"FTVA"`. The report can be run individually and is included in the "all reports" download.

This does not include the report cell border format changes ([SYS-1470](https://uclalibrary.atlassian.net/browse/SYS-1470)), as I am having problems with Excel licensing on my laptop and am waiting on a support ticket.

[SYS-1469]: https://uclalibrary.atlassian.net/browse/SYS-1469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYS-1470]: https://uclalibrary.atlassian.net/browse/SYS-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ