### PR TITLE
SYS-1472: Allow staff to delete LibraryData fund records

### DIFF
--- a/ge/templates/ge/base.html
+++ b/ge/templates/ge/base.html
@@ -6,6 +6,8 @@
         <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
+        <!-- Custom JS -->
+        <script src="{% static 'js/main.js' %}" defer></script>
     </head>
     <body>
         <ul class="navbar">

--- a/ge/templates/ge/base.html
+++ b/ge/templates/ge/base.html
@@ -7,7 +7,7 @@
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
         <!-- Custom JS -->
-        <script src="{% static 'js/main.js' %}" defer></script>
+        <script src="{% static 'js/ge_main.js' %}" defer></script>
     </head>
     <body>
         <ul class="navbar">

--- a/ge/templates/ge/edit_fund.html
+++ b/ge/templates/ge/edit_fund.html
@@ -20,6 +20,6 @@
 
 <form id="delete_fund" action="{% url 'delete_fund' form.instance.pk %}" method="post">
   {% csrf_token %}
-  <button type="submit" id="delete_submit">Delete this fund</button>
+  <button type="submit" id="delete_submit" onclick="return confirmDelete();">Delete this fund</button>
 </form>
 {% endblock %}

--- a/ge/templates/ge/edit_fund.html
+++ b/ge/templates/ge/edit_fund.html
@@ -15,7 +15,11 @@
   <table class="data-form">
     {{ form.as_table }}
   </table>
-  <button type="submit" id="edit_submit" >Save changes</button>
+  <button type="submit" id="edit_submit">Save changes</button>
 </form>
 
+<form id="delete_fund" action="{% url 'delete_fund' form.instance.pk %}" method="post">
+  {% csrf_token %}
+  <button type="submit" id="delete_submit">Delete this fund</button>
+</form>
 {% endblock %}

--- a/ge/urls.py
+++ b/ge/urls.py
@@ -4,9 +4,10 @@ from . import views
 urlpatterns = [
     path("", views.report),
     path("ge/report/", views.report),
-    path("ge/search/", views.search),
+    path("ge/search/", views.search, name="search"),
     path("ge/edit_fund/<int:item_id>", views.edit_fund, name="edit_fund"),
     path("ge/add_fund/", views.add_fund, name="add_fund"),
+    path("ge/delete_fund/<int:item_id>", views.delete_fund, name="delete_fund"),
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),

--- a/ge/views.py
+++ b/ge/views.py
@@ -115,5 +115,18 @@ def add_fund(request: HttpRequest) -> HttpResponse:
 
 
 @login_required(login_url="/login/")
+def delete_fund(request: HttpRequest, item_id: int) -> HttpResponse:
+    # Get the record passed by id.
+    record = LibraryData.objects.get(pk=item_id)
+    if request.method == "POST":
+        fund_label = record.fau_fund
+        record.delete()
+        messages.success(request, f"Fund {fund_label} deleted.")
+        return redirect("search")
+    else:
+        return render(request, "ge/edit_fund.html", kwargs={"item_id": item_id})
+
+
+@login_required(login_url="/login/")
 def release_notes(request: HttpRequest) -> HttpResponse:
     return render(request, "ge/release_notes.html")

--- a/qdb/templates/base.html
+++ b/qdb/templates/base.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}"/>
 
     <!-- Custom JS -->
-    <script src="{% static 'js/main.js' %}" defer></script>
+    <script src="{% static 'js/qdb_main.js' %}" defer></script>
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>

--- a/qdb/templates/registration/login.html
+++ b/qdb/templates/registration/login.html
@@ -24,7 +24,7 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
     
         <!-- Custom JS -->
-        <script src="{% static 'js/main.js' %}" defer></script>
+        <script src="{% static 'js/qdb_main.js' %}" defer></script>
     
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -74,3 +74,12 @@ ul.navbar {
   padding: 10px;
   border: 1px solid black;
 }
+
+#edit_fund,
+#delete_fund {
+  display: inline;
+}
+
+#delete_fund {
+  margin-left: 600px;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -83,3 +83,8 @@ ul.navbar {
 #delete_fund {
   margin-left: 600px;
 }
+
+#delete_submit {
+  background: none !important;
+  color: #ff0000;
+}

--- a/static/js/ge_main.js
+++ b/static/js/ge_main.js
@@ -1,0 +1,6 @@
+// Javascript for the GE app only; see qdb_main.js for QDB javascript.
+
+// Used in edit_fund.html to confirm deletion of a fund
+function confirmDelete(event) {
+    return confirm('Delete this fund?');
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -83,3 +83,8 @@ $(document).ready( function () {
     optionToSelect.selected = true;
     $('#id_unit').prepend(optionToSelect);
 });
+
+// Used in show_links.html to confirm link deletion
+function confirmDelete(event) {
+    return confirm('Delete this fund?');
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -84,7 +84,7 @@ $(document).ready( function () {
     $('#id_unit').prepend(optionToSelect);
 });
 
-// Used in show_links.html to confirm link deletion
+// Used in edit_fund.html to confirm deletion of a fund
 function confirmDelete(event) {
     return confirm('Delete this fund?');
 }

--- a/static/js/qdb_main.js
+++ b/static/js/qdb_main.js
@@ -1,3 +1,5 @@
+// Javascript for the QDB app only; see ge_main.js for GE javascript.
+
 const spinnerBox = document.getElementById('spinner-box')
 const longBox = document.getElementById('long-box')
 var message_box = document.getElementById("error_message");
@@ -83,8 +85,3 @@ $(document).ready( function () {
     optionToSelect.selected = true;
     $('#id_unit').prepend(optionToSelect);
 });
-
-// Used in edit_fund.html to confirm deletion of a fund
-function confirmDelete(event) {
-    return confirm('Delete this fund?');
-}


### PR DESCRIPTION
Implements [SYS-1472](https://uclalibrary.atlassian.net/browse/SYS-1472)

This PR adds the ability to delete existing funds from the GE application. This is done with a new `delete_fund` view, which is used by a new form on the `edit_fund` page. After deleting a fund, the user is redirected to the search page and shown a deletion confirmation message containing the fund's `fau_fund` value.

I went back and forth (literally) for a while on the placement of the save and delete buttons. Let me know if you have any suggestions to make sure the functions are clear to users, especially since there is no confirmation before deleting at this point.

Screenshots:

<img width="826" alt="image" src="https://github.com/UCLALibrary/LBS/assets/7283991/f150df90-561c-4d50-8caa-a0dea8ca7e8f">

-----

<img width="667" alt="image" src="https://github.com/UCLALibrary/LBS/assets/7283991/0dd740bb-6ce9-4054-b999-9422e0dfed2a">


[SYS-1472]: https://uclalibrary.atlassian.net/browse/SYS-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ