### PR TITLE
SYS-1659: Special handling of FTVA funds in QDB reports

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       COMPOSE_FILE: docker-compose.ga.yml
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Build the stack
         run: docker-compose -f $COMPOSE_FILE up --build -d

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Build the stack
-        run: docker-compose -f $COMPOSE_FILE up --build -d
+        run: docker compose -f $COMPOSE_FILE up --build -d
       
       - name: Wait for database
         run: sleep 15s
@@ -19,22 +19,22 @@ jobs:
 
         # Check logs separately, GA not showing all of both together
       - name: Logs (db)
-        run: docker-compose -f $COMPOSE_FILE logs --tail="all" db
+        run: docker compose -f $COMPOSE_FILE logs --tail="all" db
 
       - name: Logs (django)
-        run: docker-compose -f $COMPOSE_FILE logs --tail="all" django
+        run: docker compose -f $COMPOSE_FILE logs --tail="all" django
 
       - name: Containers
-        run: docker-compose -f $COMPOSE_FILE ps
+        run: docker compose -f $COMPOSE_FILE ps
 
       - name: Top processes
-        run: docker-compose -f $COMPOSE_FILE top
+        run: docker compose -f $COMPOSE_FILE top
 
       - name: Create models
-        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py migrate
+        run: docker compose -f $COMPOSE_FILE exec -T django python manage.py migrate
       
       - name: Load data
-        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py load_initial_data qdb/fixtures/staff.csv qdb/fixtures/unit.csv qdb/fixtures/accounts.csv
+        run: docker compose -f $COMPOSE_FILE exec -T django python manage.py load_initial_data qdb/fixtures/staff.csv qdb/fixtures/unit.csv qdb/fixtures/accounts.csv
       
       - name: Check connectivity
         #run: docker run --network container:django-frontend appropriate/curl -s -I http://localhost:8000/admin/
@@ -42,4 +42,4 @@ jobs:
       
       - name: Run tests
         # -T to disable TTY allocation
-        run: docker-compose -f $COMPOSE_FILE exec -T django python manage.py test qdb
+        run: docker compose -f $COMPOSE_FILE exec -T django python manage.py test qdb

--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.1.3
+  tag: 1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.4</h4>
+<p><i>August 2, 2024</i></p>
+<ul>
+    <li>Added special handling of 432975-AD-19933 for FTVA in QDB reports.</li>
+</ul>
+
 <h4>1.1.3</h4>
 <p><i>March 14, 2024</i></p>
 <ul>

--- a/qdb/forms.py
+++ b/qdb/forms.py
@@ -1,10 +1,20 @@
-
 from django import forms
 from .models import Unit
 import datetime
+
 MONTHS = [
-    ('1', 'Jan'), ('2', 'Feb'), ('3', 'Mar'), ('4', 'Apr'), ('5', 'May'), ('6', 'Jun'), ('7',
-                                                                                         'Jul'), ('8', 'Aug'), ('9', 'Sep'), ('10', 'Oct'), ('11', 'Nov'), ('12', 'Dec'),
+    ("1", "Jan"),
+    ("2", "Feb"),
+    ("3", "Mar"),
+    ("4", "Apr"),
+    ("5", "May"),
+    ("6", "Jun"),
+    ("7", "Jul"),
+    ("8", "Aug"),
+    ("9", "Sep"),
+    ("10", "Oct"),
+    ("11", "Nov"),
+    ("12", "Dec"),
 ]
 currentDateTime = datetime.datetime.now()
 date = currentDateTime.date()
@@ -21,16 +31,13 @@ elif month_now > 1 and month_now < 13:
 
 YEARS = [(year, year)]
 for i in range(1, 3):
-    YEARS.append((year-i, year-i))
+    YEARS.append((year - i, year - i))
 YEARS = tuple(YEARS)
 
 
 class ReportForm(forms.Form):
-    unit = forms.ModelChoiceField(
-        queryset=Unit.objects.all().order_by('name'))
-    year = forms.ChoiceField(
-        choices=YEARS, initial=year_default)
-    month = forms.ChoiceField(
-        choices=MONTHS, initial=month_default)
+    unit = forms.ModelChoiceField(queryset=Unit.objects.all().order_by("name"))
+    year = forms.ChoiceField(choices=YEARS, initial=year_default)
+    month = forms.ChoiceField(choices=MONTHS, initial=month_default)
     send_email = forms.BooleanField(required=False, initial=True)
     override_recipients = forms.CharField(required=False)

--- a/qdb/management/commands/run_qdb_reporter.py
+++ b/qdb/management/commands/run_qdb_reporter.py
@@ -1,32 +1,52 @@
 from django.core.management.base import BaseCommand
 from qdb.scripts.orchestrator import Orchestrator
-from qdb.scripts.settings import REPORTS_DIR, DEFAULT_RECIPIENTS, UL_NAME
+from qdb.scripts.settings import REPORTS_DIR, DEFAULT_RECIPIENTS
 
 
 class Command(BaseCommand):
     help = "Run the legacy QDB reporting tool"
 
     def add_arguments(self, parser):
-        parser.add_argument("-l", "--list_units", action="store_true",
-                            help="List all the units")
-        parser.add_argument("-y", "--year", type=int,
-                            help="Year of the report")
-        parser.add_argument("-m", "--month", type=int,
-                            help="Month number of the report")
-        parser.add_argument("-u", "--units", nargs='+',
-                            help="Unit ID number; if omitted all units will receive reports")
-        parser.add_argument("-e", "--email", action="store_true",
-                            help="Email the report to the recipients")
-        parser.add_argument("-r", "--list_recipients", action="store_true",
-                            help="Display the list of people to email for each report")
-        parser.add_argument("-o", "--override_recipients", nargs='*', default=None,
-                            help="Space-delimited email address(es) to email for each report")
+        parser.add_argument(
+            "-l", "--list_units", action="store_true", help="List all the units"
+        )
+        parser.add_argument("-y", "--year", type=int, help="Year of the report")
+        parser.add_argument(
+            "-m", "--month", type=int, help="Month number of the report"
+        )
+        parser.add_argument(
+            "-u",
+            "--unit",
+            type=int,
+            default=None,
+            required=False,
+            help="Unit ID number; if omitted all units will receive reports",
+        )
+        parser.add_argument(
+            "-e",
+            "--email",
+            action="store_true",
+            help="Email the report to the recipients",
+        )
+        parser.add_argument(
+            "-r",
+            "--list_recipients",
+            action="store_true",
+            help="Display the list of people to email for each report",
+        )
+        parser.add_argument(
+            "-o",
+            "--override_recipients",
+            nargs="*",
+            default=None,
+            help="Space-delimited email address(es) to email for each report",
+        )
 
     def handle(self, *args, **options):
         list_units = options["list_units"]
         year = options["year"]
         month = options["month"]
-        units = options["units"]
+        unit = options["unit"]
         email = options["email"]
         list_recipients = options["list_recipients"]
         override_recipients = options["override_recipients"]
@@ -37,9 +57,14 @@ class Command(BaseCommand):
             if list_units is True:
                 print(orchestrator.list_units())
             yyyymm = orchestrator.validate_date(year, month, yyyymm=True)
-            units = orchestrator.validate_units(units)
-            orchestrator.run(yyyymm, units, send_email=email,
-                             list_recipients=list_recipients, override_recipients=override_recipients)
+            units = orchestrator.get_units(unit)
+            orchestrator.run(
+                yyyymm,
+                units,
+                send_email=email,
+                list_recipients=list_recipients,
+                override_recipients=override_recipients,
+            )
             return
         except ValueError as e:
             exit(e)

--- a/qdb/scripts/orchestrator.py
+++ b/qdb/scripts/orchestrator.py
@@ -4,7 +4,6 @@ import arrow
 import logging
 import os
 import psycopg2
-
 from qdb.scripts.settings import UL_NAME
 from qdb.scripts import fetcher, formatter, sender
 from qdb.scripts.parser import Parser
@@ -167,7 +166,7 @@ class Orchestrator:
                 if len(rows) == 0:  # pragma: no cover
                     logger.warning(f"No data from QDB for {account}{cc_list}")
                     continue
-                result = parser.add_account(account, cc_list, rows)
+                result = parser.add_account(unit_id, account, cc_list, rows)
                 if result is False:  # pragma: no cover
                     logger.warning(f"Account {account} is empty. Exclude from report")
             if len(parser.data["accounts"]) == 0:  # pragma: no cover

--- a/qdb/scripts/orchestrator.py
+++ b/qdb/scripts/orchestrator.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
-
+from itertools import groupby
 import arrow
 import logging
 import os
-import psycopg2
+from qdb.models import Account, Recipient, Unit
 from qdb.scripts.settings import UL_NAME
 from qdb.scripts import fetcher, formatter, sender
 from qdb.scripts.parser import Parser
@@ -15,21 +14,6 @@ class Orchestrator:
     def __init__(self, reports_dir, recipients):
         self.reports_dir = reports_dir
         self.recipients = recipients
-        self.conn = self.get_conn()
-        self.cursor = self.conn.cursor()
-        # self.cursor.execute("SELECT * FROM qdb_unit ORDER BY name")
-        # fetch_results = self.cursor.fetchall()
-
-    def get_conn(self):
-        db_host = os.getenv("DJANGO_DB_HOST")
-        db_name = os.getenv("DJANGO_DB_NAME")
-        db_user = os.getenv("DJANGO_DB_USER")
-        db_password = os.getenv("DJANGO_DB_PASSWORD")
-
-        conn = psycopg2.connect(
-            host=db_host, dbname=db_name, user=db_user, password=db_password
-        )
-        return conn
 
     def validate_date(self, year=None, month=None, yyyymm=False):
         today = arrow.now()
@@ -50,55 +34,68 @@ class Orchestrator:
         return year, month
 
     def get_all_units(self):
-        self.cursor.execute("SELECT * FROM qdb_unit ORDER BY name")
-        results = self.cursor.fetchall()
-        return results
+        # Caller expects a list
+        units = Unit.objects.all().order_by("name")
+        return [unit for unit in units]
 
-    def list_units(self):
+    def get_units(self, unit_id: int | None = None) -> list:
+        # Caller didn't ask for a specific unit: return all
+        if unit_id is None:
+            return self.get_all_units()
+        unit = Unit.objects.get(id=unit_id)
+        # Caller asked for the "All units" "unit"
+        if unit.name == "All units":
+            return self.get_all_units()
+        else:
+            # Caller needs a list
+            return [unit]
+
+    def list_units(self) -> str:
         units = self.get_all_units()
-        name_length = max([len(u[1]) for u in units])
+        name_length = max([len(unit.name) for unit in units])
         header = "\nID | Name"
-        bar = "---|" + "-" * name_length
+        bar = "---|" + "-" * (name_length + 1)
         msg = [header, bar]
-        for row in units:
-            msg.append(f"{row[0]:>2} | {row[1]}")
+        for unit in units:
+            msg.append(f"{unit.id:>2} | {unit.name}")
         return "\n".join(msg)
 
-    def validate_units(self, unit_ids=None):
-        # similar: match multiple rows in MYSQL with info from python list
-        if unit_ids is None:
-            return self.get_all_units()
-        qms = ",".join(["%s"] * len(unit_ids))
-        cmd = f"SELECT * FROM qdb_unit WHERE id IN ({qms})"
-        self.cursor.execute(cmd, unit_ids)
-        rows = self.cursor.fetchall()
-        for row in rows:
-            if row[1] == "All units":
-                return self.get_all_units()
-        if len(rows) < len(unit_ids):
-            bad_ids = set(unit_ids) - set([r["id"] for r in rows])
-            raise ValueError(f"ERROR: Unit ID does not exist {bad_ids}")
-        return rows
+    def get_accounts_for_unit(self, unit_id: int) -> list[tuple[str, list[str]]]:
+        """Gets account and cost center information for a unit.
+        Returns a list of tuples, with each tuple consisting of 2 elements:
+        1: account
+        2: list of cost centers
+        Example response (partial):
+        [('606000', ['AD', 'LB']), ('606000', ['LM'])]
+        """
 
-    def get_accounts_for_unit(self, unit_id):
-        # separate Library Materials (LM) from other cost centers, as requested
-        cmd = """
-            SELECT qdb_account.account, string_agg(qdb_account.cost_center, ',') AS cc_list
-            FROM qdb_account, qdb_unit
-            WHERE qdb_account.cost_center != 'LM'
-            AND qdb_account.cost_center != ''
-            AND qdb_account.unit_id = qdb_unit.id
-            AND qdb_unit.id = %s
-            GROUP BY qdb_account.account
-            UNION
-            SELECT qdb_account.account, qdb_account.cost_center AS cc_list
-            FROM qdb_account, qdb_unit
-            WHERE qdb_account.cost_center = 'LM'
-            AND qdb_account.unit_id = qdb_unit.id
-            AND qdb_unit.id = %s"""
-        self.cursor.execute(cmd, [unit_id, unit_id])
-        results = self.cursor.fetchall()
-        return [(row[0], row[1].split(",")) for row in sorted(results)]
+        # Data can be obtained by a union of 2 queries which each use the
+        # postgresql-specific string_agg() function, but that's complex and not
+        # database-agnostic.  Instead, use 2 simple ORM queries and basic python.
+
+        # Separate Library Materials (LM) from other cost centers, as requested.
+        lm_data = (
+            Account.objects.filter(unit_id=unit_id, cost_center="LM")
+            .values_list("account", "cost_center")
+            .order_by("account", "cost_center")
+        )
+        # Legacy query explicitly excluded accounts with no cost center.
+        non_lm_data = (
+            Account.objects.filter(unit_id=unit_id)
+            .exclude(cost_center__in=["LM", ""])
+            .values_list("account", "cost_center")
+            .order_by("account", "cost_center")
+        )
+
+        accounts = []
+        for data in [lm_data, non_lm_data]:
+            structured_accounts = [
+                (k, [v for _, v in g]) for k, g in groupby(list(data), lambda x: x[0])
+            ]
+            accounts.extend(structured_accounts)
+
+        # Make sure integrated list of accounts is sorted.
+        return sorted(accounts)
 
     def cleanup_reports_dir(self):
         for f in os.listdir(self.reports_dir):
@@ -109,25 +106,35 @@ class Orchestrator:
             except FileNotFoundError:
                 logger.error(f"Could not delete from reports directory: {f}")
 
-    def get_recipients(self, unit_id, unit_name):
-        # recipients is initialized to either developers (dev mode) or to LBS (prod mode);
-        # unit recipients are added.
+    def get_recipients(self, unit_id: int, unit_name: str) -> set:
+        """Gets the recipients (email addresses) to which a unit's report
+        should be sent.
+        """
+
+        # This is set on class instantiation based on DEFAULT_RECIPIENTS,
+        # either to developers (dev mode) or to LBS (prod mode).
         recipients = set(self.recipients)
-        cmd = """
-            SELECT email
-            FROM qdb_staff, qdb_unit, qdb_recipient
-            WHERE qdb_recipient.unit_id = %s
-            AND qdb_staff.name != %s"""
+
+        # Legacy code alert: Apparently, if unit_name parameter is "LBS", only the
+        # unit head should get the report, instead of all unit-designated recipients.
+        # Normally, caller passes a matching unit_id and unit_name... but maybe this
+        # used to be an override, an "LBS-mode"? Web UI does not support this now, though.
         if unit_name == "LBS":
-            cmd += " AND (qdb_staff.id = qdb_recipient.recipient_id"
-            cmd += " AND qdb_recipient.role = 'head')"
+            roles = ["head"]
         else:
-            cmd += """
-              AND ((qdb_staff.id = qdb_recipient.recipient_id AND qdb_recipient.role = 'head')
-                OR (qdb_staff.id = qdb_recipient.recipient_id AND qdb_recipient.role = 'aul')
-                OR (qdb_staff.id = qdb_recipient.recipient_id AND qdb_recipient.role = 'assoc'))"""
-        self.cursor.execute(cmd, [unit_id, UL_NAME])
-        recipients.update([r[0] for r in self.cursor.fetchall()])
+            roles = ["aul", "head", "assoc"]
+
+        # Legacy code alert: The University Librarian (UL) apparently is not supposed to get
+        # these reports... even though that person is not listed as a recipient.  Seems like
+        # if the UL is acting head of a unit, they'd want to get this report....?
+        # UL_NAME comes from imported settings.
+        unit_recipients = (
+            Recipient.objects.filter(unit_id=unit_id, role__in=roles)
+            .exclude(recipient__name=UL_NAME)
+            .values_list("recipient__email", flat=True)
+        )
+
+        recipients.update(unit_recipients)
         return recipients
 
     def generate_filename(self, unit_name, yyyymm):

--- a/qdb/scripts/orchestrator.py
+++ b/qdb/scripts/orchestrator.py
@@ -122,8 +122,8 @@ class Orchestrator:
 
         # Legacy code alert: Apparently, if unit_name parameter is "LBS", only the
         # unit head should get the report, instead of all unit-designated recipients.
-        # Normally, caller passes a matching unit_id and unit_name... but maybe this
-        # used to be an override, an "LBS-mode"? Web UI does not support this now, though.
+        # Normally, everyone in LBS_RECIPIENTS (which is used for DEFAULT_RECIPIENTS
+        # in production) will get a copy of every report.
         if unit_name == "LBS":
             roles = ["head"]
         else:

--- a/qdb/scripts/orchestrator.py
+++ b/qdb/scripts/orchestrator.py
@@ -89,6 +89,11 @@ class Orchestrator:
 
         accounts = []
         for data in [lm_data, non_lm_data]:
+            # Each "data" is a Django QuerySet containing a list of tuples
+            # (account, cost center), and many accounts have multiple cost centers.
+            # Example input: [("606000", "AD"), ("606000", "LB")]
+            # Convert each data list into a tuple (account, [list of cost centers]).
+            # Example output: [("606000", ["AD", "LB"])]
             structured_accounts = [
                 (k, [v for _, v in g]) for k, g in groupby(list(data), lambda x: x[0])
             ]
@@ -150,8 +155,8 @@ class Orchestrator:
         list_recipients=False,
     ):
         for unit in units:
-            unit_id = unit[0]
-            unit_name = unit[1]
+            unit_id = unit.id
+            unit_name = unit.name
             if override_recipients is not None:
                 recipients = override_recipients
             else:

--- a/qdb/scripts/parser.py
+++ b/qdb/scripts/parser.py
@@ -42,7 +42,31 @@ class Parser:
                 return False
         return True
 
-    def add_account(self, account, cc_list, rows):
+    def exclude_ftva_aul_row(self, unit_id, row):
+        # Handle FTVA AUL fund reporting differently, per SYS-1659.
+
+        # Should only get called for relevant units, but check anyhow.
+        # Unit 27: FTVA; unit 35: HaDuong - AUL Discretionary Funds
+        if unit_id not in [27, 35]:
+            # Not a relevant unit, tell caller not to exclude it.
+            return False
+
+        account_number = row["account_number"]
+        cost_center = row["cost_center_code"]
+        fund_number = row["fund_number"]
+        # Look at 432975-AD funds only
+        if (account_number, cost_center) != ("432975", "AD"):
+            # Not a relevant fund, tell caller not to exclude it.
+            return False
+
+        # If unit is FTVA (27), exclude 432975-AD-19933;
+        if unit_id == 27:
+            return fund_number == "19933"
+        # if unit is HaDuong - AUL Discretionary Funds (35), exclude all except 432975-AD-19933.
+        if unit_id == 35:
+            return fund_number != "19933"
+
+    def add_account(self, unit_id, account, cc_list, rows):
         acct_dict = {
             "title": rows[0]["account_title"].strip(),
             "account": account,
@@ -52,6 +76,12 @@ class Parser:
         for row in rows:
             if self.exclude(row):
                 continue
+            # Handle FTVA AUL fund reporting differently, per SYS-1659
+            # Unit 27: FTVA; unit 35: HaDuong - AUL Discretionary Funds
+            if unit_id in [27, 35]:
+                if self.exclude_ftva_aul_row(unit_id, row):
+                    continue
+
             fau = f"{row['account_number']}-{row['cost_center_code']}-{row['fund_number']}"
             if fau not in acct_dict["faus"].keys():
                 acct_dict["faus"][fau] = {"fund_title": row["fund_title"], "subs": {}}

--- a/qdb/scripts/parser.py
+++ b/qdb/scripts/parser.py
@@ -42,14 +42,14 @@ class Parser:
                 return False
         return True
 
-    def exclude_ftva_aul_row(self, unit_id, row):
+    def exclude_ftva_aul_row(self, unit_id: int, row: dict):
         # Handle FTVA AUL fund reporting differently, per SYS-1659.
 
         # Should only get called for relevant units, but check anyhow.
         # Unit 27: FTVA; unit 35: HaDuong - AUL Discretionary Funds
         if unit_id not in [27, 35]:
-            # Not a relevant unit, tell caller not to exclude it.
-            return False
+            # Not a relevant unit, tell caller it made a mistake.
+            raise ValueError(f"Call this only with units 27 or 35, not {unit_id}")
 
         account_number = row["account_number"]
         cost_center = row["cost_center_code"]

--- a/qdb/scripts/settings.py
+++ b/qdb/scripts/settings.py
@@ -25,7 +25,7 @@ DB_PASSWORD = os.environ.get("QDB_DB_PASSWORD", "")  # not relevant for CI build
 REPORTS_DIR = os.path.join(BASE_DIR, "reports")
 
 # University Librarian
-UL_NAME = "Ginny Steel"
+UL_NAME = "Athena Jackson"
 
 # Staff contacts
 LBS_CONTACT = "Doris Wang"
@@ -40,7 +40,6 @@ SLDS_CONTACT_EMAIL = "joshuagomez@library.ucla.edu"
 TEST_RECIPIENT = os.environ.get("QDB_TEST_RECIPIENT", FROM_ADDRESS)
 
 DEV_RECIPIENTS = [
-    "joshuagomez@library.ucla.edu",  # Joshua Gomez
     "akohler@library.ucla.edu",  # Andy Kohler
 ]
 

--- a/qdb/tests.py
+++ b/qdb/tests.py
@@ -12,7 +12,6 @@ import os
 
 class AdminTestCase(TestCase):
     fixtures = ["sample_data.json"]
-    nameunit = Unit.objects.get(name="Oral History")
 
     def test_recipientadmin(self):
         recipient = Recipient.objects.get(pk=1)
@@ -85,6 +84,8 @@ class FormatterTest(TestCase):
 
 
 class OrchestratorTest(TestCase):
+    fixtures = ["sample_data.json"]
+
     def setUp(self):
         self.orch = Orchestrator(REPORTS_DIR, DEFAULT_RECIPIENTS)
 
@@ -151,14 +152,15 @@ class OrchestratorTest(TestCase):
             self.orch.validate_date(2020, 13, True)
 
     def test_get_all_units(self):
-        units = self.orch.get_all_units()
+        # get_units() with no parameter gets all units
+        units = self.orch.get_units()
         self.assertEqual(type(units), list)
         self.assertTrue(len(units) > 0)
 
-    def test_validate_gets_all_units(self):
-        units = self.orch.validate_units()
+    def test_get_single_unit(self):
+        units = self.orch.get_units(27)
         self.assertEqual(type(units), list)
-        self.assertTrue(len(units) > 0)
+        self.assertEqual(len(units), 1)
 
     def test_get_accounts_for_unit(self):
         results = self.orch.get_accounts_for_unit(27)

--- a/qdb/tests.py
+++ b/qdb/tests.py
@@ -207,7 +207,7 @@ class OrchestratorTest(TestCase):
 
 class ParserTest(TestCase):
     def setUp(self):
-        self.parser = Parser("202101", "Access Services")
+        self.parser = Parser("202101", "Fake unit")
 
     def test_calculate_percent(self):
         actual = self.parser.calculate_percent_left(100, 50)
@@ -288,3 +288,51 @@ class ParserTest(TestCase):
             "ytd_expense": Decimal("0"),
         }
         self.assertTrue(self.parser.exclude(row))
+
+    def test_exclude_ftva_aul_row_raises_error_with_wrong_unit(self):
+        # Only valid for units 27 and 35, caller is responsible.
+        with self.assertRaises(ValueError):
+            self.parser.exclude_ftva_aul_row(unit_id=99, row={})
+
+    def test_exclude_ftva_aul_row_skips_irrelevant_funds(self):
+        # Irrelevant funds (those without the specific account or cost center
+        # we care about) do not get excluded from their reports.
+        # Caller: exclude this?
+        # Response: No (False), do not exclude it.
+        # Only valid for units 27 and 35.
+        row = {
+            "account_number": "invalid",
+            "cost_center_code": "invalid",
+            "fund_number": "irrelevant",
+        }
+        self.assertFalse(self.parser.exclude_ftva_aul_row(unit_id=27, row=row))
+
+    def test_exclude_ftva_aul_row_ftva_fund_number(self):
+        # Only valid for units 27 and 35.
+        # Relevant funds are "432975-AD-*" only.
+        # Unit 27 (FTVA report) excludes fund number 19933, allows all others.
+        row = {
+            "account_number": "432975",
+            "cost_center_code": "AD",
+            "fund_number": "19933",
+        }
+        # True, it's excluded
+        self.assertTrue(self.parser.exclude_ftva_aul_row(unit_id=27, row=row))
+        row["fund_number"] = "not 19933"
+        # False, it's not excluded (allowed)
+        self.assertFalse(self.parser.exclude_ftva_aul_row(unit_id=27, row=row))
+
+    def test_exclude_ftva_aul_row_aul_fund_number(self):
+        # Only valid for units 27 and 35.
+        # Relevant funds are "432975-AD-*" only.
+        # Unit 35 (FTVA AUL report) includes fund number 19933, excludes all others.
+        row = {
+            "account_number": "432975",
+            "cost_center_code": "AD",
+            "fund_number": "19933",
+        }
+        # False, 19933 is not excluded
+        self.assertFalse(self.parser.exclude_ftva_aul_row(unit_id=35, row=row))
+        row["fund_number"] = "not 19933"
+        # True, non-19933 is excluded
+        self.assertTrue(self.parser.exclude_ftva_aul_row(unit_id=35, row=row))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ Django==4.2.11
 gunicorn==21.2.0
 openpyxl==3.1.2
 pandas==2.1.1
+# numpy version used by pandas must be < 2.0.0
+numpy==1.26.4
 psycopg2==2.9.7
 python-tds==1.13.0
 pytz==2023.3.post1


### PR DESCRIPTION
Implements [SYS-1659](https://uclalibrary.atlassian.net/browse/SYS-1659). Tagged as version `1.1.4` for release.

This PR primarily adds functionality to the QDB reports application, by allowing one specific fund (432975-AD-19933) to be handled specially.  QDB reports normally include funds based on account and cost center only, not fund number - so, all of `432975-AD` normally would be included in whatever reports are relevant.  However, this specific fund `432975-AD-19933` should **not** appear on the FTVA report (though all other `432975-AD-*` should), and it **should** appear on the AUL Discretionary fund report for FTVA (but no other `432975-AD-*` should).

This change is implemented via changes to the `Parser` class, mainly via a new `exclude_ftva_aul_row()` method.  Since the desired change is far more specific than the application is designed for, I chose to hard-code the relevant values here (and in new tests), rather than try to generalize into model changes or even environmental variables.  This is fragile, but the internal values of `Unit.id` referenced are unlikely to ever change.  I think this is OK; the application will need significant changes if/when the campus changes financial systems anyhow.

While adding this functionality, I found that unrelated code in the `Orchestrator` class, which works with data from the Django database, was written to directly query the database, instead of going through the Django ORM.  Beyond just being "bad" and "wrong", it meant that tests which use `Orchestrator` were unable to use the normal test database Django creates & destroys when tests run, and were highly dependent on the correct data being in the local "production" database.

I rewrote all of the relevant code to use the Django ORM (or general Python, in one case).  This allows all tests to run correctly, against an ephemeral test database, as they should.

The PR also includes minor changes:
* Reformatting of several files which had not been run through `Black` before
* Cleanup of some code which had been shifted from the prior command-line reporting utility to Django without enough review

The new code is more consistent with our current standards (type hints, naming).  I didn't try to modernize code if I wasn't changing it.

### Testing
Confirm that `docker-compose exec django python manage.py test qdb` runs 33 tests, all passing.
The full suite `docker-compose exec django python manage.py test` runs 80 tests, all passing.

Otherwise, please focus on code changes in `qdb/scripts/parser.py` and `qdb/scripts/orchestrator.py`, along with changes to `tests.py`.  Is the code clear enough, etc.?  The logic in `parser.py` uses more double-negatives than I like: True, this fund is not wanted, exclude it from a report... but I didn't find a clearer way to express the logic.  Suggestions welcome!


[SYS-1659]: https://uclalibrary.atlassian.net/browse/SYS-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ