### PR TITLE
SYS-1672: Image and security updates

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -31,8 +31,10 @@ jobs:
         run: echo "${{ steps.yaml-data.outputs.data }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: uclalibrary/lbs:${{ steps.yaml-data.outputs.data }}
+          tags: |
+            uclalibrary/lbs:${{ steps.yaml-data.outputs.data }}
+            uclalibrary/lbs:scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 RUN apt-get update
 

--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.1.4
+  tag: 1.1.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose.ga.yml
+++ b/docker-compose.ga.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     container_name: django-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/docker-compose_PGADMIN.yml
+++ b/docker-compose_PGADMIN.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,6 +4,13 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.5</h4>
+<p><i>September 6, 2024</i></p>
+<ul></ul>
+    <li>Updated Python to version 3.12 and Debian to version 12 (Bookworm).</li>
+    <li>Updated Django and gunicorn packages to patch security issues.</li>
+</ul>
+
 <h4>1.1.4</h4>
 <p><i>August 2, 2024</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,16 @@
 arrow==1.2.3
 asgiref==3.7.2
-Django==4.2.11
-gunicorn==21.2.0
+Django==4.2.16
+gunicorn==23.0.0
 openpyxl==3.1.2
 pandas==2.1.1
 # numpy version used by pandas must be < 2.0.0
 numpy==1.26.4
 psycopg2==2.9.7
 python-tds==1.13.0
+# python-tds (pytds) requires pkg_resources from setuptools,
+# but assumes it's installed... it's not, by default.
+setuptools==74.1.2
 pytz==2023.3.post1
 sqlparse==0.4.4
 whitenoise==6.5.0


### PR DESCRIPTION
Implements [SYS-1672](https://uclalibrary.atlassian.net/browse/SYS-1672). Bumps version to `v1.1.5` for deployment.

Upgrades without functionality changes. Includes:
* Base image updated to use Debian 12 and Python 3.12
* Django updated to 4.2.16 and gunicorn updated to 23.0.0 to address security alerts.
* Added setuptools to `requirements.txt` - it's needed by `python-tds` (for SQL Server communication), but apparently no longer supplied by default in the base Python image
* Removed version declaration from docker-compose files
* Updated workflows to use latest actions versions and added `scan` tag to Docker Hub image

Build logs should be clean: `docker compose --progress plain build > build.log`

80 tests should pass: `docker-compose exec django python manage.py test`

The [application](http://127.0.0.1:8000/) should allow login with admin/admin.


[SYS-1672]: https://uclalibrary.atlassian.net/browse/SYS-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ