### PR TITLE
SYS-1678: update sqlparse package

### DIFF
--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.1.5
+  tag: 1.1.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -7,7 +7,7 @@
 <h4>1.1.6</h4>
 <p><i>September 10, 2024</i></p>
 <ul>
-    <li>Updated sqlparse package to patch security issue.</li>
+    <li>Removed sqlparse package from requirements.txt since it's installed by Django automatically.</li>
 </ul>
 
 

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,9 +4,16 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.1.6</h4>
+<p><i>September 10, 2024</i></p>
+<ul>
+    <li>Updated sqlparse package to patch security issue.</li>
+</ul>
+
+
 <h4>1.1.5</h4>
 <p><i>September 6, 2024</i></p>
-<ul></ul>
+<ul>
     <li>Updated Python to version 3.12 and Debian to version 12 (Bookworm).</li>
     <li>Updated Django and gunicorn packages to patch security issues.</li>
 </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-tds==1.13.0
 # but assumes it's installed... it's not, by default.
 setuptools==74.1.2
 pytz==2023.3.post1
-sqlparse==0.4.4
+sqlparse==0.5.1
 whitenoise==6.5.0
 # Used by pandas for Excel .xls support
 xlrd==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ python-tds==1.13.0
 # but assumes it's installed... it's not, by default.
 setuptools==74.1.2
 pytz==2023.3.post1
-sqlparse==0.5.1
 whitenoise==6.5.0
 # Used by pandas for Excel .xls support
 xlrd==2.0.1


### PR DESCRIPTION
Implements [SYS-1678](https://uclalibrary.atlassian.net/browse/SYS-1678)

Updates sqlparse package from 0.4.4 to 0.5.1 to address [dependabot alert](https://github.com/UCLALibrary/LBS/security/dependabot/22). Includes release notes and tag bump for deployment.

After restarting, 80 tests should pass (`docker-compose exec django python manage.py test`) and [application](http://127.0.0.1:8000/) should allow login with admin/admin.

[SYS-1678]: https://uclalibrary.atlassian.net/browse/SYS-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ