### PR TITLE
SYS-1827: Upgrade Django, Python, and PostgreSQL

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -9,7 +9,7 @@
 ###
 
 # Used in lbs/settings.py
-DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
+DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
 DJANGO_DB_NAME=qdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 RUN apt-get update
 
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg2 python module.
+# Install dependencies needed to build psycopg python module.
 RUN apt-get install -y gcc python3-dev libpq-dev
 
 # For this application, also install cron and sudo,

--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.2.1
+  tag: 1.2.2
   pullPolicy: Always
 
 nameOverride: ""
@@ -44,7 +44,7 @@ django:
       - lbs.library.ucla.edu
     csrf_trusted_origins:
       - https://lbs.library.ucla.edu
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "qdb"
     db_user: "qdb"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/docker-compose.ga.yml
+++ b/docker-compose.ga.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker-compose_PGADMIN.yml
+++ b/docker-compose_PGADMIN.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Check when database is ready for connections
 echo "Checking database connectivity..."
-until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+until python -c 'import os, psycopg ; conn = psycopg.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"
   sleep 5
 done

--- a/ge/forms.py
+++ b/ge/forms.py
@@ -76,7 +76,7 @@ class ReportForm(forms.Form):
             ("sel", "SEL"),
             ("ul", "UL"),
             ("aul_benedetti", "AUL Benedetti"),
-            ("aul_consales", "AUL Consales"),
+            ("aul_gomez", "AUL Gomez"),
             ("aul_grappone", "AUL Grappone"),
         ],
         widget=forms.Select(),

--- a/ge/templates/ge/base.html
+++ b/ge/templates/ge/base.html
@@ -17,7 +17,10 @@
             <li><a href="/qdb/report/">QDB Reports</a></li>
             <li><a href="/logs/">Logs</a></li>
             <li><a href="/release_notes/">Release Notes</a></li>
-            <li><a href="/qdb/logout/">Logout</a></li>
+            <li><form action="{% url 'logout' %}" method="post">
+                {% csrf_token %}
+                <button class="button-link" type="submit">Logout</button>
+                </form></li>
         </ul>
         <br>
         <div>

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.2.2</h4>
+<p><i>May 16, 2025</i></p>
+<ul>
+    <li>Updated Django to 5.2.1 and Python to 3.13.</li>
+</ul>   
+
 <h4>1.2.1</h4>
 <p><i>February 28, 2025</i></p>
 <ul>

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -628,9 +628,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
         for col in ("L", "M", "N", "O", "P", "Q", "S"):
             for row in range(5, len(ws[col]) + 1):
                 # Excel "format code" for Accounting, 2 decimal places, $, comma separator
-                ws[
-                    f"{col}{row}"
-                ].number_format = (
+                ws[f"{col}{row}"].number_format = (
                     """_($* #,##0.00_);_($* (#,##0.00);_($* " - "??_);_(@_)"""
                 )
         # add filters on all cols
@@ -668,7 +666,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
             "sel": ["SEL"],
             "ul": ["UL"],
             "aul_benedetti": ["Benedetti"],
-            "aul_consales": ["Consales"],
+            "aul_gomez": ["Gomez"],
             "aul_grappone": ["Grappone"],
         }
 
@@ -678,7 +676,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
         gifts_qset = LibraryData.objects.none()
 
         # AUL reports require fuzzy matching on unit and home_unit_dept
-        if rpt_type in ["aul_benedetti", "aul_consales", "aul_grappone"]:
+        if rpt_type in ["aul_benedetti", "aul_gomez", "aul_grappone"]:
             endowments_qset = LibraryData.objects.filter(
                 unit__icontains=rpt_query_dict[rpt_type][0]
             ).filter(fund_type="Endowment").order_by(
@@ -815,9 +813,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
             sum_col(gifts_ws, col)
             for row in range(5, len(gifts_ws[col]) + 1):
                 # Excel "format code" for Accounting, 2 decimal places, $, comma separator
-                gifts_ws[
-                    f"{col}{row}"
-                ].number_format = (
+                gifts_ws[f"{col}{row}"].number_format = (
                     """_($* #,##0.00_);_($* (#,##0.00);_($* " - "??_);_(@_)"""
                 )
 
@@ -825,9 +821,7 @@ def create_excel_output(rpt_type: str) -> Workbook:
             sum_col(endowments_ws, col)
             for row in range(5, len(endowments_ws[col]) + 1):
                 # Excel "format code" for Accounting, 2 decimal places, $, comma separator
-                endowments_ws[
-                    f"{col}{row}"
-                ].number_format = (
+                endowments_ws[f"{col}{row}"].number_format = (
                     """_($* #,##0.00_);_($* (#,##0.00);_($* " - "??_);_(@_)"""
                 )
 
@@ -882,9 +876,9 @@ def download_excel_file(rpt_type: str) -> HttpResponse:
         content=stream,
         content_type="application/ms-excel",
     )
-    response[
-        "Content-Disposition"
-    ] = f'attachment; filename={rpt_type}-Report-{datetime.now().strftime("%Y%m%d%H%M")}.xlsx'
+    response["Content-Disposition"] = (
+        f'attachment; filename={rpt_type}-Report-{datetime.now().strftime("%Y%m%d%H%M")}.xlsx'
+    )
 
     return response
 

--- a/qdb/templates/base.html
+++ b/qdb/templates/base.html
@@ -65,13 +65,13 @@
             <!-- Header -->
             <div id="header">
                 <div id="branding">
-                    <h1 id="site-name"><a href="/admin/">QDB Reports</a></h1>
+                    <h1 class="qdb-header"><a href="/admin/">QDB Reports</a></h1>
                     <h1>|</h1>
-                    <h1 id="site-name"><a href="/ge/report/">GE Reports</a></h1>
+                    <h1 class="qdb-header"><a href="/ge/report/">GE Reports</a></h1>
                     <h1>|</h1>
-                    <h1 id="site-name"><a href="/qdb/cron/">QDB Scheduling</a></h1>
+                    <h1 class="qdb-header"><a href="/qdb/cron/">QDB Scheduling</a></h1>
                     <h1>|</h1>
-                    <h1 id="site-name"><a href="/logs/">Logs</a></h1>
+                    <h1 class="qdb-header"><a href="/logs/">Logs</a></h1>
                 </div>
                 <div id="user-tools">
                     Welcome,

--- a/qdb/templates/base.html
+++ b/qdb/templates/base.html
@@ -77,7 +77,10 @@
                     Welcome,
                     <strong>{{request.user.username}}</strong>.
                     <a href="/admin/">View admin page</a> /
-                    <a href="/qdb/logout/">Log out</a>
+                    <form id="logout-form" action="{% url 'logout' %}" method="post">
+                        {% csrf_token %}
+                        <button type="submit">Log out</button>
+                    </form>
                 </div>
             </div>
         </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 arrow==1.2.3
-asgiref==3.7.2
-Django==4.2.19
+asgiref==3.8.1
+Django==5.2.1
 gunicorn==23.0.0
 openpyxl==3.1.2
-pandas==2.1.1
-# numpy version used by pandas must be < 2.0.0
-numpy==1.26.4
-psycopg2==2.9.7
+pandas==2.2.3
+psycopg==3.2.9
 python-tds==1.13.0
 # python-tds (pytds) requires pkg_resources from setuptools,
 # but assumes it's installed... it's not, by default.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -102,3 +102,15 @@ button.button-link {
   background: none !important;
   color: #ff0000;
 }
+
+.qdb-header {
+  padding: 0 1rem;
+  margin: 0;
+  font-weight: 300;
+  font-size: 1.5rem;
+}
+.qdb-header a,
+#branding h1 {
+  color: var(--header-branding-color) !important;
+  margin: 0;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -49,6 +49,20 @@ ul.navbar {
   text-decoration: none;
 }
 
+button.button-link {
+  background: none;
+  border: none;
+  font-size: inherit;
+  font-family: inherit;
+  color: #007bff;
+  display: block;
+  text-align: center;
+  padding: 10px 12px;
+  height: 24px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 .tooltip {
   position: relative;
   display: inline-block;

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -14,5 +14,8 @@
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
                 {% endif %}
-                <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+                <form id="logout-form" action="{% url 'logout' %}" method="post">
+                {% csrf_token %}
+                <button type="submit">Log out</button>
+                </form>
             {% endblock %}


### PR DESCRIPTION
Implements [SYS-1827](https://uclalibrary.atlassian.net/browse/SYS-1827)

Upgrades Python to 3.13, Django to 5.2.1, and PostgreSQL to 16. 

**Note:** several packages in `requirements.txt` were updated to support the new versions of Django and Python. `pandas` is among these - 2.2.3, the latest release, is the first to support Python 3.13. Before now, we had pinned `numpy` at an older version (see [comment in current requirements.txt](https://github.com/UCLALibrary/LBS/blob/e4efdad704a9888803dd15f92b2959cb16019a6a/requirements.txt#L7)), which is not compatible with `pandas` 2.2.3. I'm not sure why this was needed at the time. I've run a few test reports and the resulting Excel files look ok to me, but I don't know exactly what to look for. 

In addition to updating the Logout links to send POST requests, some CSS and HTML changes were needed to fix the styling of the navbar in the QDB interface.

### Testing

Remove old volumes, if needed
`docker volume rm lbs_pg_data`
`docker volume rm lbs_pgadmin_data`  

Build and run containers (including separate pgAdmin container)
`docker compose build`
`docker compose up -d`
`docker compose -f docker-compose_PGADMIN.yml up -d`

Run tests - 84, all passing
`docker compose exec django python manage.py test`

Check out the application in the browser: http://localhost:8000/admin/.
Check out pgAdmin in the browser:  http://localhost:5050/ (additional setup instructions in the [README](https://github.com/UCLALibrary/LBS/blob/main/README.md))

[SYS-1827]: https://uclalibrary.atlassian.net/browse/SYS-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ