### PR TITLE
Downgrade numpy to work around deployment issue

### DIFF
--- a/charts/prod-lbs-values.yaml
+++ b/charts/prod-lbs-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/lbs
-  tag: 1.2.5
+  tag: 1.2.6
   pullPolicy: Always
 
 nameOverride: ""

--- a/ge/templates/ge/release_notes.html
+++ b/ge/templates/ge/release_notes.html
@@ -4,6 +4,12 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.2.6</h4>
+<p><i>January 9, 2026</i></p>
+<ul>
+    <li>Downgrade numpy to 2.3.5 per <a href="https://uclalibrary.atlassian.net/browse/DIGINF-262">deployment issue</a>.</li>
+</ul>
+
 <h4>1.2.5</h4>
 <p><i>January 8, 2026</i></p>
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ Django==5.2.10
 gunicorn==23.0.0
 openpyxl==3.1.2
 pandas==2.2.3
+# Pin numpy to 2.3.5 for now, see DIGINF-262
+numpy==2.3.5
 psycopg==3.2.9
 python-tds==1.13.0
 # python-tds (pytds) requires pkg_resources from setuptools,


### PR DESCRIPTION
This PR works around a deployment issue caused by the latest version of `numpy`.  See [DIGINF-262](https://uclalibrary.atlassian.net/browse/DIGINF-262) for the underlying issue, which will be resolved in the future.


[DIGINF-262]: https://uclalibrary.atlassian.net/browse/DIGINF-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ