### PR TITLE
DLSR-386: Add QDB query for GE campus data (WIP)

### DIFF
--- a/ge/templates/ge/report_from_qdb_temp.html
+++ b/ge/templates/ge/report_from_qdb_temp.html
@@ -1,0 +1,33 @@
+{% extends 'ge/base.html' %}
+
+{% block content %}
+
+{% if messages %}
+<div class="box">
+{% for message in messages %}
+  <div>{{ message }}</div>
+{% endfor %}
+</div>
+{% endif %}
+<br>
+<p><b>UCLA VPN CONNECTION REQUIRED</b></p>
+<p>Select a report to generate and download it to your computer.
+  <br>
+Or download all reports in one zip file (takes about 30-40 seconds) *** DISABLED FOR NOW.</p>
+<form id="get_report" method="get" name="get_report">
+  {% csrf_token %}
+  {{ report_form.as_p }}
+  <button type="submit" name="report_submit">Get report</button>
+  <!--- <button type="submit" name="download_zip_submit">Download all reports</button> --->
+</form>
+
+<!--- Temporary for testing-->
+{% if qdb_data %}
+<code>
+    {% for row in qdb_data %}
+        <p>{{ row }}</p>
+    {% endfor %}
+</code>
+{% endif %}
+
+{% endblock %}

--- a/ge/urls.py
+++ b/ge/urls.py
@@ -11,4 +11,6 @@ urlpatterns = [
     path("logs/", views.show_log, name="show_log"),
     path("logs/<int:line_count>", views.show_log, name="show_log"),
     path("release_notes/", views.release_notes, name="release_notes"),
+    # TODO: Change this temporary path & view name, when original report is fully replaced.
+    path("ge/report_from_qdb_temp/", views.report_from_qdb_temp),
 ]

--- a/ge/views.py
+++ b/ge/views.py
@@ -15,6 +15,7 @@ from ge.views_utils import (
     download_excel_file,
     download_zip_file,
     get_librarydata_results,
+    get_qdb_data,
     import_excel_data,
     update_data,
 )
@@ -134,3 +135,26 @@ def delete_fund(request: HttpRequest, item_id: int) -> HttpResponse:
 @login_required(login_url="/login/")
 def release_notes(request: HttpRequest) -> HttpResponse:
     return render(request, "ge/release_notes.html")
+
+
+@login_required(login_url="/login/")
+def report_from_qdb_temp(request: HttpRequest) -> HttpResponse:
+    context = {}
+    if request.method == "POST":
+        # Make sure report_form is initialized, for later use.
+        report_form = ReportForm()
+    elif "report_submit" in request.GET:
+        report_form = ReportForm(request.GET)
+        if report_form.is_valid():
+            report_type = request.GET.get("report_type", "")
+            # Original method
+            # return download_excel_file(report_type)
+            # Temporary new method
+            qdb_data = get_qdb_data(report_type)
+            context = {"report_form": report_form, "qdb_data": qdb_data}
+    elif "download_zip_submit" in request.GET:
+        return download_zip_file()
+    else:
+        report_form = ReportForm()
+        context = {"report_form": report_form}
+    return render(request, "ge/report_from_qdb_temp.html", context)

--- a/ge/views_utils.py
+++ b/ge/views_utils.py
@@ -1,10 +1,12 @@
-from functools import reduce
 import logging
 import zipfile
-from django.db.models import Model, Q
 import pandas as pd
+import pytds
+
+from django.db.models import Model, Q
 from datetime import datetime
 from django.http import HttpResponse
+from functools import reduce
 from openpyxl import load_workbook
 from openpyxl.styles.borders import Border, Side
 from openpyxl.utils import get_column_letter
@@ -16,6 +18,7 @@ from tempfile import NamedTemporaryFile
 from ge.forms import ReportForm
 from ge.models import BFSImport, CDWImport, LibraryData, MTFImport
 from lbs.settings import BASE_DIR
+from qdb.scripts.settings import DB_SERVER, DB_DATABASE, DB_USER, DB_PASSWORD
 
 logger = logging.getLogger(__name__)
 
@@ -925,3 +928,67 @@ def add_border_formatting(ws: Worksheet) -> None:
     ws[f"{get_column_letter(last_border_col - 1)}3"].border = Border(
         right=Side(border_style="medium"), bottom=Side(border_style="medium")
     )
+
+
+def get_qdb_query(report_type: str) -> str:
+    # TODO: Splice this into create_excel_output() or similar, when local data is finalized.
+    QDB_GE_QUERY = """
+        select
+            fun.fund_title
+        ,	fun.foundatn_fund_num
+        ,	glb.account_number
+        ,	glb.cost_center_code
+        ,	glb.fund_number
+        ,	fun.fund_purpose_code
+        ,	fun.fund_restr_code
+        ,	sum (-glb.ytd_appropriation) AS ytd_approp
+        ,	sum (glb.ytd_financial) AS ytd_expense
+        ,	sum (glb.encumbrance) AS encumbrance
+        ,	sum (glb.memo_lien) AS memo_lien
+        ,	sum (-glb.bal_operating) AS operating_bal_am
+        FROM qdb.dbo.gl_balances glb
+        INNER JOIN qdb.dbo.account acc
+            ON glb.location_code = acc.location_code
+            AND glb.account_number = acc.account_number
+            AND glb.cost_center_code = acc.cost_center_code
+        INNER JOIN qdb.dbo.fund fun
+            ON glb.location_code = fun.location_code
+            AND glb.fund_number = fun.fund_number
+        -- Hard-coded filters first
+        WHERE glb.location_code = '4'
+        AND (glb.dept_code_account LIKE '54%%' OR glb.dept_code_account = '0461')
+        AND fun.fund_closed_flag <> 'Y'
+        -- Variable filters provided by caller
+        -- TODO: Pass these to query
+        AND glb.account_number = '603500'
+        AND glb.cost_center_code = 'MU'
+        AND glb.fund_number in ('40075', '50133', '56979')
+        AND glb.ledger_year_month = '202604'
+        GROUP BY
+            fun.fund_title
+        ,	fun.foundatn_fund_num
+        ,	glb.account_number
+        ,	glb.cost_center_code
+        ,	glb.fund_number
+        ,	fun.fund_purpose_code
+        ,	fun.fund_restr_code
+        -- ORDER BY fau, glb.sub_code
+        ;
+        """
+    return QDB_GE_QUERY
+
+
+def get_qdb_data(report_type) -> list:
+    conn = pytds.connect(DB_SERVER, DB_DATABASE, DB_USER, DB_PASSWORD)
+    # Connection and cursor are closed automatically via 'with'
+    with conn:
+        conn.as_dict = True
+        cursor = conn.cursor()
+        # TODO: Query will be built based on parameters passed to this method.
+        # For now, just use static query.
+        qdb_query = get_qdb_query(report_type)
+        # Run query with the other, real, parameters
+        # cursor.execute(qdb_final_query % (yyyymm, account_number))
+        cursor.execute(qdb_query)
+        rows = cursor.fetchall()
+        return rows


### PR DESCRIPTION
Implements [DLSR-386](https://uclalibrary.atlassian.net/browse/DLSR-386).  Internal only, not tagged for release.

This PR starts the work to move the GE reports from manually uploaded campus data to use the campus QDB (Query Data Base, containing financial data).  This is work in progress, to be via future tickets and branches.  It's internal only, not remotely ready for release.  For now, there is no change to existing functionality - if this were released, nobody would notice.

Changes:
* A new URL route is added, with a temporary name: http://127.0.0.1:8000/ge/report_from_qdb_temp/
* A basic underlying view reuses `ge.ReportForm` to provide a list of unit/report types
* New utility views run a QDB query, returning data
  * For now, this query has hard-coded parameters; these will be derived from local data later
* A basic new template dumps the data from QDB to confirm it works

There are no new tests, no new functionality beyond the above.

Manual testing:
1. Connect to the UCLA VPN, or be on campus (required for QDB queries)
2. Go to http://127.0.0.1:8000/ge/report_from_qdb_temp/ (standard developer admin login)
3. Choose any report type, they're not used yet
4. Click "Get report"
5. After 1-2 seconds, 3 ugly rows of data should be displayed below the form.


[DLSR-386]: https://uclalibrary.atlassian.net/browse/DLSR-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ